### PR TITLE
Autodetect if the default RTDB should be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,6 @@ Note: The information printed by the `init` command can be accessed from within
 your Firebase project. It’s safe to run the `python3 cli/src/cli.py init
 --use-default-rtdb` command multiple times to view this information.
 
-3. The  `–use-default-rtdb` flag must be set when running any Snapshot Debugger
-   CLI commands.
-
 ## Set up Snapshot Debugger in your Google Cloud project
 
 To use the preview Snapshot Debugger, it’s necessary to set a flag to use the
@@ -320,8 +317,6 @@ directory unless otherwise specified.
 python3 cli/src/cli.py list_debuggees
 ```
 
-Add the `--use-default-rtdb` flag if you are using the free Firebase Spark plan.
-
 The output resembles the following:
 
 ```
@@ -347,7 +342,6 @@ python3 cli/src/cli.py set_snapshot index.js:21 --debuggee-id 2054916c4b46c04e04
 Where:
 *   `index.js:21` is the `file:line` for the snapshot
 
-Add the `--use-default-rtdb` flag if you are using the Firebase Spark plan.
 
 #### Snapshot conditions (optional)
 
@@ -416,8 +410,6 @@ python3 cli/src/cli.py set_snapshot index.js:26 --debuggee-id 2054916c4b46c04e04
 python3 cli/src/cli.py list_snapshots --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --include-inactive
 ```
 
-Add the `--use-default-rtdb` flag if you are using the Firebase Spark plan.
-
 The output resembles the following:
 
 ```
@@ -440,8 +432,6 @@ python3 cli/src/cli.py get_snapshot b-1649947203 --debuggee-id 2054916c4b46c04e0
 
 Where:
 *   `b-1649947203` is the snapshot ID
-
-Add the `--use-default-rtdb` flag if you are using the Firebase Spark plan.
 
 The output resembles the following:
 
@@ -497,8 +487,6 @@ Function              Location
 ```
 python3 cli/src/cli.py delete_snapshots --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --include-inactive
 ```
-
-Add the `--use-default-rtdb` flag if you are using the Firebase Spark plan.
 
 The output resembles the following:
 
@@ -570,7 +558,7 @@ python3 cli/src/cli.py list_debuggees
 
 
 Usage: `cli.py list_debuggees [-h] [--database-url DATABASE_URL] [--format
-FORMAT] [--use-default-rtdb] [--debug]`
+FORMAT] [--debug]`
 
 Used to display a list of the debug targets (debuggees) registered with the
 Snapshot Debugger.
@@ -580,9 +568,8 @@ Snapshot Debugger.
 | Argument                      | Description |
 |-------------------------------|-------------|
 | `-h`, `--help`                | Show this help message and exit. |
-| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. If you are on the Spark plan and want the CLI to use the default instance use the --use-default-rtdb flag instead. If neither of the --database-id or --use-default-rtdb flags are used with the init command, the CLI uses the default url.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
+| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. It is only required if the `--database-id` argument was used with the init command.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
 | `--format FORMAT`             | Set the format for printing command output resources. The default is a command-specific human-friendly output format. The supported formats are: `default`, `json` (raw) and `pretty-json` (formatted `json`). |
-| `--use-default-rtdb`          | Required for projects on the Spark plan. When specified, instructs the CLI to use the project's default Firebase RTDB database. |
 | `--debug`                     | Enable CLI debug messages. |
 
 
@@ -593,7 +580,7 @@ python3 cli/src/cli.py set_snapshot
 ```
 
 Usage: `cli.py set_snapshot [-h] [--database-url DATABASE_URL]
-[--use-default-rtdb] [--debug] [--condition CONDITION] [--expression EXPRESSION]
+[--debug] [--condition CONDITION] [--expression EXPRESSION]
 [--debuggee-id DEBUGGEE_ID] location`
 
 Creates a snapshot on a debug target (Debuggee). Snapshots allow you to capture
@@ -618,8 +605,7 @@ again. It is also possible to inspect snapshot results with the
 |-------------------------------|-------------|
 | `-h`, `--help`                | Show this help message and exit. |
 | `--debuggee-id DEBUGGEE_ID`   | Specify the debuggee ID. It must be an ID obtained from the list_debuggees command. This value is required, it must be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DEBUGGEE_ID` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. If you are on the Spark plan and want the CLI to use the default instance use the --use-default-rtdb flag instead. If neither of the --database-id or --use-default-rtdb flags are used with the init command, the CLI uses the default url.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--use-default-rtdb`          | Required for projects on the Spark plan. When specified, instructs the CLI to use the project's default Firebase RTDB database. |
+| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. It is only required if the `--database-id` argument was used with the init command.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
 | `--debug`                     | Enable CLI debug messages. |
 | `--condition CONDITION`       | Specify a condition to restrict when the snapshot is taken. When the snapshot location is executed, the condition will be evaluated, and the snapshot is generated if the condition is true. |
 | `--expression EXPRESSION`     | Specify an expression to evaluate when the snapshot is taken. You may specify `--expression` multiple times. |
@@ -632,7 +618,7 @@ python3 cli/src/cli.py list_snapshots
 
 
 Usage: `cli.py list_snapshots [-h] [--database-url DATABASE_URL] [--format
-FORMAT] [--use-default-rtdb] [--debug] [--include-inactive]
+FORMAT] [--debug] [--include-inactive]
 [--debuggee-id DEBUGGEE_ID]`
 
 Used to display the debug snapshots for a debug target (debuggee). By default
@@ -646,8 +632,7 @@ all active snapshots are returned. To obtain completed snapshots specify the
 | -h, --help                    | Show this help message and exit. |
 | `--include-inactive`          | Include completed snapshots. |
 | `--debuggee-id DEBUGGEE_ID`   | Specify the debuggee ID. It must be an ID obtained from the list_debuggees command. This value is required, it must be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DEBUGGEE_ID` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. If you are on the Spark plan and want the CLI to use the default instance use the --use-default-rtdb flag instead. If neither of the --database-id or --use-default-rtdb flags are used with the init command, the CLI uses the default url.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--use-default-rtdb`          | Required for projects on the Spark plan. When specified, instructs the CLI to use the project's default Firebase RTDB database. |
+| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. It is only required if the `--database-id` argument was used with the init command.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
 | `--format FORMAT`             | Set the format for printing command output resources. The default is a command-specific human-friendly output format. The supported formats are: `default`, `json` (raw) and `pretty-json` (formatted `json`). |
 | `--debug`                     | Enable CLI debug messages. |
 
@@ -658,7 +643,7 @@ python3 cli/src/cli.py get_snapshot
 ```
 
 Usage: `cli.py get_snapshot [-h] [--database-url DATABASE_URL] [--format FORMAT]
-[--use-default-rtdb] [--debug] [--frame-index FRAME_INDEX] [--max-level
+[--debug] [--frame-index FRAME_INDEX] [--max-level
 MAX_LEVEL] [--debuggee-id DEBUGGEE_ID]`
 
 Used to retrieve a debug snapshot from a debug target (debuggee). If the
@@ -682,8 +667,7 @@ form which is intended to be machine-readable rather than human-readable.
 | -h, --help                    | Show this help message and exit. |
 | `--include-inactive`          | Include completed snapshots. |
 | `--debuggee-id DEBUGGEE_ID`   | Specify the debuggee ID. It must be an ID obtained from the list_debuggees command. This value is required, it must be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DEBUGGEE_ID` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. If you are on the Spark plan and want the CLI to use the default instance use the --use-default-rtdb flag instead. If neither of the --database-id or --use-default-rtdb flags are used with the init command, the CLI uses the default url.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--use-default-rtdb`          | Required for projects on the Spark plan. When specified, instructs the CLI to use the project's default Firebase RTDB database. |
+| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. It is only required if the `--database-id` argument was used with the init command.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
 | `--format FORMAT`             | Set the format for printing command output resources. The default is a command-specific human-friendly output format. The supported formats are: `default`, `json` (raw) and `pretty-json` (formatted `json`). |
 | `--debug`                     | Enable CLI debug messages. |
 | ` --frame-index FRAME_INDEX`  | Set the stack frame to display local variables from, the default is 0, which is the top of the stack. |
@@ -697,7 +681,7 @@ python3 cli/src/cli.py delete_snapshots
 ```
 
 Usage: `cli.py delete_snapshots [-h] [--database-url DATABASE_URL] [--format
-FORMAT] [--use-default-rtdb] [--debug] [--all-users] [--include-inactive]
+FORMAT] [--debug] [--all-users] [--include-inactive]
 [--quiet] [--debuggee-id DEBUGGEE_ID] [ID ...]`
 
 Used to delete snapshots from a debug target (debuggee). You are prompted for
@@ -718,8 +702,7 @@ confirmation before any snapshots are deleted. To suppress confirmation, use the
 | -h, --help                    | Show this help message and exit. |
 | `--include-inactive`          | Include completed snapshots. |
 | `--debuggee-id DEBUGGEE_ID`   | Specify the debuggee ID. It must be an ID obtained from the list_debuggees command. This value is required, it must be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DEBUGGEE_ID` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. If you are on the Spark plan and want the CLI to use the default instance use the --use-default-rtdb flag instead. If neither of the --database-id or --use-default-rtdb flags are used with the init command, the CLI uses the default url.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--use-default-rtdb`          | Required for projects on the Spark plan. When specified, instructs the CLI to use the project's default Firebase RTDB database. |
+| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. It is only required if the `--database-id` argument was used with the init command.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
 | `--format FORMAT`             | Set the format for printing command output resources. The default is a command-specific human-friendly output format. The supported formats are: `default`, `json` (raw) and `pretty-json` (formatted `json`). |
 | `--debug`                     | Enable CLI debug messages. |
 | ` --all-users`                | If set, snapshots from all users will be deleted, rather than only snapshots created by the current user. This flag is not required when specifying the exact ID of a snapshot. |

--- a/cli/src/cli_common_arguments.py
+++ b/cli/src/cli_common_arguments.py
@@ -26,12 +26,10 @@ DEBUGGEE_ID_ENV_VAR_NAME = 'SNAPSHOT_DEBUGGER_DEBUGGEE_ID'
 DATABASE_URL_HELP = f"""
 Specify the database URL for the CLI to use. This should only be used as an
 override to make the CLI talk to a specific instance and isn't expected to be
-needed. If you are on the Spark plan and want the CLI to use the default
-instance use the --use-default-rtdb flag instead. If neither of the
---database-id or --use-default-rtdb flags are used with the init command, the
-CLI uses the default url.  This value may be specified either via this command
-line argument or via the '{DATABASE_URL_ENV_VAR_NAME}' environment variable.
-When both are specified, the value from the command line takes precedence.
+needed. It is only required if the '--database-id' argument was used with the
+init command.  This value may be specified either via this command line argument
+or via the '{DATABASE_URL_ENV_VAR_NAME}' environment variable.  When both
+are specified, the value from the command line takes precedence.
 """
 
 FORMAT_HELP = """
@@ -41,11 +39,6 @@ command-specific human-friendly output format. The supported formats are:
 """
 
 DEBUG_HELP = 'Enable CLI debug messages.'
-
-USE_DEFAULT_RTDB_HELP = """
-Required for projects on the Spark plan. When specified, instructs the CLI to
-use the project's default Firebase RTDB database.
-"""
 
 DEBUGGEE_ID_HELP = f"""
 Specify the debuggee ID. It must be an ID obtained from the list_debuggees
@@ -64,14 +57,12 @@ class CommonArgumentParsers:
   Attributes:
     database_url: Argument parser for the 'database-url' cli argument.
     format: Argument parser for the 'format' cli argument.
-    use_default_rtdb: Argument parser for the 'use-default-rtdb' cli argument.
     debuggee_id: Argument parser for the 'debuggee-id' cli argument.
   """
 
   def __init__(self):
     self.database_url = self.create_database_url_parser()
     self.format = self.create_format_parser()
-    self.use_default_rtdb = self.create_use_default_rtdb_parser()
     self.debuggee_id = self.create_debuggee_id_parser()
 
   @staticmethod
@@ -93,13 +84,6 @@ class CommonArgumentParsers:
   def create_format_parser():
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('--format', help=FORMAT_HELP, default='default')
-    return parser
-
-  @staticmethod
-  def create_use_default_rtdb_parser():
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument(
-        '--use-default-rtdb', help=USE_DEFAULT_RTDB_HELP, action='store_true')
     return parser
 
   @staticmethod

--- a/cli/src/cli_services.py
+++ b/cli/src/cli_services.py
@@ -38,9 +38,8 @@ FIREBASE_DEFAULT_RTDB_ID = '{project_id}-default-rtdb'
 
 CHECK_CONFIGURATION_MSG = """
 Confirm the correct project has been configured and that the 'init' command has
-been run.  See
-https://github.com/GoogleCloudPlatform/snapshot-debugger/blob/main/README.md for
-more information.
+been run.  See https://github.com/GoogleCloudPlatform/snapshot-debugger for more
+information.
 """
 
 

--- a/cli/src/cli_services.py
+++ b/cli/src/cli_services.py
@@ -14,6 +14,8 @@
 """Contains service instances and base config required by the commands.
 """
 
+from exceptions import SilentlyExitError
+from firebase_types import DatabaseGetStatus
 from firebase_types import FirebaseProject
 from firebase_management_rest_service import FirebaseManagementRestService
 from firebase_rtdb_rest_service import FirebaseRtdbRestService
@@ -23,8 +25,8 @@ from permissions_rest_service import PermissionsRestService
 from user_input import UserInput
 from user_output import UserOutput
 
-# Unless specified otherwise, our preferred Database ID has this format.
-CDBG_DEFAULT_DB_ID = '{project_id}-cdbg'
+# The default/preferred Database ID the CLI attempts to use has this format.
+SNAPSHOT_DEBUGGER_DEFAULT_DB_ID = '{project_id}-cdbg'
 
 # All Firebase projects can have one default rtdb instance. It will have that
 # following format. In some very rare cases it could be different, and the
@@ -32,14 +34,6 @@ CDBG_DEFAULT_DB_ID = '{project_id}-cdbg'
 # when possible we do the right thing and get it from there, however this is
 # used as a fall back when required.
 FIREBASE_DEFAULT_RTDB_ID = '{project_id}-default-rtdb'
-
-# The URLs for Firebase RTDBs come in two flavours:
-#
-# DATABASE_NAME.firebaseio.com for databases in us-central1
-# DATABASE_NAME.REGION.firebasedatabase.app for databases in all other locations
-#
-# For now we only support the location of us-central1
-DEFAULT_DB_URL = 'https://{database_id}.firebaseio.com'
 
 
 class CliServices:
@@ -109,14 +103,12 @@ class CliServices:
 
     return self._firebase_rtdb_service
 
-  def get_default_database_id(self):
-    return CDBG_DEFAULT_DB_ID.format(project_id=self.project_id)
+  def get_snapshot_debugger_default_database_id(self):
+    return SNAPSHOT_DEBUGGER_DEFAULT_DB_ID.format(project_id=self.project_id)
 
-  def get_default_database_url(self):
-    return DEFAULT_DB_URL.format(database_id=self.get_default_database_id())
-
-  def get_database_id(self, args, firebase_project: FirebaseProject = None):
-    """Determines the database_id based on the args and project configuration.
+  def get_firebase_default_rtdb_id(self,
+                                   firebase_project: FirebaseProject = None):
+    """Determines the default RTDB instance ID.
 
     A note on terminology here, database ID, database Name and database instance
     effectively refer to the same thing. For instance, for a database with URL
@@ -124,34 +116,70 @@ class CliServices:
     which happens to be globally unique across all firebase projects.
 
     Args:
-      args: These are the parsed command line arguments.
       firebase_project: An instance of the current firebase project if the
         caller already has it, it can be None otherwise.
 
     Returns:
-      The appropriate database ID for the caller to use.
+      The appropriate database ID for the caller to use. If the project did not
+      have a default RTDB instance, None is returned.
+    """
+    if firebase_project is None:
+      project_response = self.firebase_management_service.project_get()
+      firebase_project = project_response.firebase_project
+
+    default_rtdb = None
+
+    if firebase_project is not None:
+      default_rtdb = firebase_project.default_rtdb_instance
+
+    if default_rtdb is None:
+      default_rtdb = FIREBASE_DEFAULT_RTDB_ID.format(project_id=self.project_id)
+
+    return default_rtdb
+
+  def get_database_url(self, args):
+    """Determines the database URL to use.
+
+     The URLs for Firebase RTDBs come in two flavours:
+
+       DATABASE_NAME.firebaseio.com for databases in us-central1
+       DATABASE_NAME.REGION.firebasedatabase.app for databases in all other
+         locations
+
+    See https://firebase.google.com/docs/database/rest/start#create_a_database
+    and https://firebase.google.com/docs/projects/locations#rtdb-locations for
+    more information.
+
+    Args:
+      args: These are the parsed command line arguments.
+
+    Returns:
+      The appropriate database URL for the caller to use.
     """
 
-    if 'database_id' in args and args.database_id is not None:
-      return args.database_id
+    if 'database_url' in args and args.database_url is not None:
+      self.output.debug(f'Using user specified database {args.datbase_url}')
+      return args.database_url
 
-    if 'use_default_rtdb' in args and args.use_default_rtdb:
-      if firebase_project is None:
-        project_response = self.firebase_management_service.project_get()
-        firebase_project = project_response.firebase_project
+    is_db_configured, db_url = self.get_database_url_from_id(
+        self.get_snapshot_debugger_default_database_id())
 
-      default_rtdb = None
+    # If the prefered default was not found, try the defaut firebase RTDB, this
+    # would be configured if '--use-default-rtdb' was used with the init
+    # command.
+    if not is_db_configured:
+      is_db_configured, db_url = self.get_database_url_from_id(
+          self.get_firebase_default_rtdb_id())
 
-      if firebase_project is not None:
-        default_rtdb = firebase_project.default_rtdb_instance
+    if not is_db_configured:
+      self.user_output.error(
+          'Failed to find a configured database for project '
+          f"{self.project_id}. Ensure the 'init' command has been successfuly "
+          'run on it')
+      raise SilentlyExitError
 
-      if default_rtdb is None:
-        default_rtdb = FIREBASE_DEFAULT_RTDB_ID.format(
-            project_id=self.project_id)
-
-      return default_rtdb
-
-    return CDBG_DEFAULT_DB_ID.format(project_id=self.project_id)
+    self.user_output.debug(f'Using configured database {db_url}')
+    return db_url
 
   def get_database_url_from_id(self, database_id):
     """Determines the database URL based on the database_id.
@@ -162,23 +190,24 @@ class CliServices:
     Returns:
       The appropriate database URL for the caller to use.
     """
-    # Note, for now we only support the one default location, so the below
-    # is fine. However this could be modified to peform an instance get call
-    # that would return the URL for the database.
-    return DEFAULT_DB_URL.format(database_id=database_id)
+    instance_response = self.firebase_management_service.rtdb_instance_get(
+        database_id)
 
-  def get_database_url(self, args):
-    """Determines the database URL to use.
+    if instance_response.status != DatabaseGetStatus.EXISTS:
+      self.user_output.debug(f'Database ID: {database_id} does not exist')
+      return (False, None)
 
-    Args:
-      args: These are the parsed command line arguments.
+    db_url = instance_response.database_instance.database_url
 
-    Returns:
-      The appropriate database URL for the caller to use.
-    """
+    rtdb_service = FirebaseRtdbRestService(
+        http_service=self.http_service,
+        database_url=db_url,
+        user_output=self.user_output)
 
-    if 'database_url' in args and args.database_url is not None:
-      return args.database_url
+    is_configured = rtdb_service.get('schema_version') is not None
 
-    database_id = self.get_database_id(args)
-    return self.get_database_url_from_id(database_id)
+    self.user_output.debug(
+        f'Database ID: {database_id}, URL: {db_url}, is configured: '
+        f'{is_configured}')
+
+    return (is_configured, db_url)

--- a/cli/src/delete_snapshots_command.py
+++ b/cli/src/delete_snapshots_command.py
@@ -74,7 +74,7 @@ class DeleteSnapshotsCommand:
   def register(self, args_subparsers, required_parsers, common_parsers):
     parent_parsers = [
         common_parsers.database_url, common_parsers.format,
-        common_parsers.use_default_rtdb, common_parsers.debuggee_id
+        common_parsers.debuggee_id
     ]
     parent_parsers += required_parsers
     parser = args_subparsers.add_parser(

--- a/cli/src/firebase_management_rest_service.py
+++ b/cli/src/firebase_management_rest_service.py
@@ -171,6 +171,7 @@ class FirebaseManagementRestService:
       response = self.http_service.send(request, handle_http_error=False)
     except HTTPError as err:
       if err.code == 404:
+        print_http_error(self.user_output, request, err, is_debug_message=True)
         self.user_output.debug("Got 404, DB did not exist")
         return DatabaseGetResponse(status=DatabaseGetStatus.DOES_NOT_EXIST)
 

--- a/cli/src/firebase_types.py
+++ b/cli/src/firebase_types.py
@@ -19,6 +19,9 @@ The types here help work with the data and response messages from Firebase.
 from enum import Enum
 from exceptions import SilentlyExitError
 
+FIREBASE_MANAGMENT_API_SERVICE = 'firebase.googleapis.com'
+FIREBASE_RTDB_MANAGMENT_API_SERVICE = 'firebasedatabase.googleapis.com'
+
 
 class FirebaseProjectStatus(Enum):
   ENABLED = 1

--- a/cli/src/firebase_types.py
+++ b/cli/src/firebase_types.py
@@ -31,6 +31,11 @@ class FirebaseProject:
   Documentation for what's expected to be in a FirebaseProject can be found
   here:
   https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects#FirebaseProject
+
+  Attributes:
+    default_rtdb_instance: The project's default RTDB database instance. This
+    value is the name of the instance (not a URL). A value of None indicates the
+    project has no default instance.
   """
 
   def __init__(self, firebase_project):

--- a/cli/src/get_snapshot_command.py
+++ b/cli/src/get_snapshot_command.py
@@ -62,7 +62,7 @@ class GetSnapshotCommand:
   def register(self, args_subparsers, required_parsers, common_parsers):
     parent_parsers = [
         common_parsers.database_url, common_parsers.format,
-        common_parsers.use_default_rtdb, common_parsers.debuggee_id
+        common_parsers.debuggee_id
     ]
     parent_parsers += required_parsers
     parser = args_subparsers.add_parser(

--- a/cli/src/init_command.py
+++ b/cli/src/init_command.py
@@ -18,6 +18,8 @@ resources so Snapshot Debugger can use Firebase as a backend.
 """
 
 import time
+from firebase_types import FIREBASE_MANAGMENT_API_SERVICE
+from firebase_types import FIREBASE_RTDB_MANAGMENT_API_SERVICE
 from firebase_types import DatabaseCreateStatus
 from firebase_types import DatabaseGetStatus
 from firebase_types import FirebaseProjectStatus
@@ -64,10 +66,6 @@ FIREBASE_MANAGEMENT_API_URL = (
 ENABLE_FIREBASE_API_GCLOUD_CMD = """
 gcloud services enable firebase.googleapis.com
 """
-
-FIREBASE_MANAGMENT_API_SERVICE = 'firebase.googleapis.com'
-
-FIREBASE_RTDB_MANAGMENT_API_SERVICE = 'firebasedatabase.googleapis.com'
 
 BILLING_PLAN_URL = ('https://console.firebase.google.com/project/{project_id}/'
                     'usage/details')

--- a/cli/src/init_command.py
+++ b/cli/src/init_command.py
@@ -22,7 +22,7 @@ from firebase_types import DatabaseCreateStatus
 from firebase_types import DatabaseGetStatus
 from firebase_types import FirebaseProjectStatus
 from exceptions import SilentlyExitError
-from cli_services import CDBG_DEFAULT_DB_ID
+from cli_services import SNAPSHOT_DEBUGGER_DEFAULT_DB_ID
 
 DATABASE_ID_HELP = """
 Specify the ID of the database instance for the CLI to create as part of the
@@ -41,6 +41,11 @@ DEFAULT_LOCATION = 'us-central1'
 
 LOCATION_HELP = f"""
 Location for the database instance, defaults to {DEFAULT_LOCATION}
+"""
+
+USE_DEFAULT_RTDB_HELP = """
+Required for projects on the Spark plan. When specified, instructs the CLI to
+use the project's default Firebase RTDB database.
 """
 
 FIREBASE_CONSOLE_URL = ('https://console.firebase.google.com/project/'
@@ -81,7 +86,7 @@ REQUIRED_PERMISSIONS = [
 
 MIGRATE_PROJECT_INSTRUCTIONS = """
 Your Google Cloud project must be enabled for Firebase resources. To do so,
-complete the following steps and then then run the init command again.
+complete the following steps and then run the init command again.
 
 1. Enable your Google Cloud project for Firebase resources.
 
@@ -203,13 +208,16 @@ class InitCommand:
     pass
 
   def register(self, args_subparsers, required_parsers, common_parsers):
-    parent_parsers = [common_parsers.use_default_rtdb]
-    parent_parsers += required_parsers
+    unused_common_parsers = common_parsers
+    parent_parsers = required_parsers
     parser = args_subparsers.add_parser(
         'init', description=CMD_DESCRIPTION, parents=parent_parsers)
     parser.add_argument(
+        '--use-default-rtdb', help=USE_DEFAULT_RTDB_HELP, action='store_true')
+    parser.add_argument(
         '--database-id',
-        help=DATABASE_ID_HELP.format(default_database_id=CDBG_DEFAULT_DB_ID))
+        help=DATABASE_ID_HELP.format(
+            default_database_id=SNAPSHOT_DEBUGGER_DEFAULT_DB_ID))
     parser.set_defaults(func=self.cmd)
 
     # Only some locations are supported, see:
@@ -328,7 +336,7 @@ class InitCommand:
       self.gcloud_service.enable_api(FIREBASE_RTDB_MANAGMENT_API_SERVICE)
 
   def check_and_handle_database_instance(self, args, firebase_project):
-    database_id = self.services.get_database_id(
+    database_id = self.get_database_id(
         args=args, firebase_project=firebase_project)
 
     instance_response = self.firebase_management_service.rtdb_instance_get(
@@ -360,6 +368,15 @@ class InitCommand:
       raise SilentlyExitError
 
     return database_instance
+
+  def get_database_id(self, args, firebase_project=None):
+    if 'database_id' in args and args.database_id is not None:
+      return args.database_id
+
+    if 'use_default_rtdb' in args and args.use_default_rtdb:
+      return self.services.get_firebase_default_rtdb_id(firebase_project)
+
+    return self.services.get_snapshot_debugger_default_database_id()
 
   def handle_database_create_failed(self, database_id, create_response):
     if create_response.status == DatabaseCreateStatus.FAILED_PRECONDITION:

--- a/cli/src/list_debuggees_command.py
+++ b/cli/src/list_debuggees_command.py
@@ -44,10 +44,7 @@ class ListDebuggeesCommand:
     pass
 
   def register(self, args_subparsers, required_parsers, common_parsers):
-    parent_parsers = [
-        common_parsers.database_url, common_parsers.format,
-        common_parsers.use_default_rtdb
-    ]
+    parent_parsers = [common_parsers.database_url, common_parsers.format]
     parent_parsers += required_parsers
     parser = args_subparsers.add_parser(
         'list_debuggees', description=DESCRIPTION, parents=parent_parsers)

--- a/cli/src/list_snapshots_command.py
+++ b/cli/src/list_snapshots_command.py
@@ -56,7 +56,7 @@ class ListSnapshotsCommand:
   def register(self, args_subparsers, required_parsers, common_parsers):
     parent_parsers = [
         common_parsers.database_url, common_parsers.format,
-        common_parsers.use_default_rtdb, common_parsers.debuggee_id
+        common_parsers.debuggee_id
     ]
     parent_parsers += required_parsers
     parser = args_subparsers.add_parser(

--- a/cli/src/set_snapshot_command.py
+++ b/cli/src/set_snapshot_command.py
@@ -77,7 +77,7 @@ class SetSnapshotCommand:
   def register(self, args_subparsers, required_parsers, common_parsers):
     parent_parsers = [
         common_parsers.database_url, common_parsers.format,
-        common_parsers.use_default_rtdb, common_parsers.debuggee_id
+        common_parsers.debuggee_id
     ]
     parent_parsers += required_parsers
     parser = args_subparsers.add_parser(


### PR DESCRIPTION
The CLI will now test for a configured Snapshot Debugger database instance of `{project_id}-cdbg`.  Failing that it will then test the default Firebase RTDB instance to see if it has been configured for use by the Snapshot Debugger. This removes the need for the `--use-default-rtdb` argument from all commands other than the `init` command.
    
The `--database-url` override option remains when needed to provide a specific URL to use.

Fixes #5 