### PR TITLE
Clean up user output for stdout/stderr

### DIFF
--- a/cli/src/format_utils.py
+++ b/cli/src/format_utils.py
@@ -50,6 +50,6 @@ def print_table(user_output, headers, values):
 
 def print_json(user_output, json_doc, pretty=False):
   if pretty:
-    user_output.normal(json.dumps(json_doc, indent=2))
+    user_output.json_data(json.dumps(json_doc, indent=2))
   else:
-    user_output.normal(json.dumps(json_doc))
+    user_output.json_data(json.dumps(json_doc))

--- a/cli/src/user_output.py
+++ b/cli/src/user_output.py
@@ -27,24 +27,68 @@ class UserOutput:
   to the user. Depending on the message type, it will be output to the correct
   location, eg stdout or stderr. For debug messages, they will be suppressed
   unless debugging has been enabled.
+
+  All non json output goes to stderr, and everything else, including debug level
+  messages go to stderr. This is done to keep things simple and allows for the
+  case where the CLI is being driven prgramatically, then only formatted JSON
+  ends up in stdout.
   """
 
   def __init__(self, is_debug_enabled):
+    """Initializes the UserOuput instance.
+
+    Args:
+      is_debug_enabled: Flag that when true indicates debug messages should be
+        emitted. The are suppressed otherwise.
+    """
     self._is_debug_enabled = is_debug_enabled
 
-  # Debug messages that are output when the user enables the --debug option.
-  # For instance this should be used for outputting REST calls and their
-  # responses, etc.
   def debug(self, *args, **kwargs):
+    """Outputs a debug message.
+
+    This method is meant for any debug messages that will only be emitted when
+    the --debug options is has been specified on the CLI input line.
+    The output goes to stderr (as stdout is reserved for JSON output only).
+
+    Args:
+      args: Variable length unnamed argument list which will be passed to print.
+      kwargs: Variable length named argument list which will be passed to print.
+    """
     if self._is_debug_enabled:
-      print(*args, **kwargs)
+      print(*args, file=sys.stderr, **kwargs)
 
-  # Normal user output when providing output information from a successful
-  # command.
   def normal(self, *args, **kwargs):
+    """Outputs a normal user message.
+
+    This method is meant for any normal user output when providing information
+    from a successful command. The output goes to stderr (as stdout is reserved
+    for JSON output only).
+
+    Args:
+      args: Variable length unnamed argument list which will be passed to print.
+      kwargs: Variable length named argument list which will be passed to print.
+    """
     print(*args, file=sys.stderr, **kwargs)
 
-  # Meant for anything 'exceptional', that is not part of the normal user output
-  # when the commands succeeds.
   def error(self, *args, **kwargs):
+    """Outputs an error message to the user.
+
+    This method is meant for anything 'exceptional', that is not part of the
+    normal user output when the commands succeeds. The output goes to stderr.
+
+    Args:
+      args: Variable length unnamed argument list which will be passed to print.
+      kwargs: Variable length named argument list which will be passed to print.
+    """
     print(*args, file=sys.stderr, **kwargs)
+
+  def json_data(self, data):
+    """Outputs json data to stdout.
+
+    Outputs the data (which is expected to be in json format already) to stdout.
+
+    Args:
+      data: The JSON data to emit, which is expected to be a JSON formatted str.
+    """
+
+    print(data, file=sys.stdout)


### PR DESCRIPTION
Ensure all users messages go to stderr, while stdout is reserved for
JSON formatted messages.

Fixes #2.