### PR TITLE
Add warning about node version in GCE sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Firebase backend.
 If you don’t have a project yet and want to try out Snapshot Debugger, follow
 the steps in [Getting started with Node.js on Compute Engine | Google
 Cloud](https://cloud.google.com/nodejs/getting-started/getting-started-on-compute-engine)
-to create one.
+to create one.  (Note that you may need to upgrade to a more recent version of node.)
 
 ### Set up Google Compute Engine
 


### PR DESCRIPTION
As of today the GCE getting started sample uses v8.12.0 of node.  Apparently that is before try/catch is supported so when adding the agent you'll get "SyntaxError: Unexpected } catch {}".  This is resolved by upgrading.