### PR TITLE
Address warnings with newer version of pylint.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -76,7 +76,7 @@ disable=abstract-method,
         global-statement,
         hex-method,
         idiv-method,
-        implicit-str-concat-in-sequence,
+        implicit-str-concat,
         import-error,
         import-self,
         import-star-module-level,
@@ -154,12 +154,6 @@ disable=abstract-method,
 # (visual studio) and html. You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
 output-format=text
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]". This option is deprecated
-# and it will be removed in Pylint 2.0.
-files-output=no
 
 # Tells whether to display a full report or only the messages
 reports=no
@@ -278,12 +272,6 @@ ignore-long-lines=(?x)(
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=yes
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=
 
 # Maximum number of lines in a module
 max-module-lines=99999

--- a/snapshot_dbg_cli/data_formatter.py
+++ b/snapshot_dbg_cli/data_formatter.py
@@ -38,8 +38,8 @@ class DataFormatter:
         also match the length of the headers tuple.
     """
     widths = [
-        max(len(headers[i]), max([len(v[i])
-                                  for v in values], default=0))
+        max(len(headers[i]), max((len(v[i])
+                                  for v in values), default=0))
         for i in range(len(headers))
     ]
 


### PR DESCRIPTION
- Sync with latest https://google.github.io/styleguide/pylintrc.
- Fix warning in data_formatter module, use generator instead of list
  comprehension.

Fixes #49