### PR TITLE
Delete unused variables at start of function.

### DIFF
--- a/snapshot_dbg_cli/init_command.py
+++ b/snapshot_dbg_cli/init_command.py
@@ -206,7 +206,7 @@ class InitCommand:
     pass
 
   def register(self, args_subparsers, required_parsers, common_parsers):
-    unused_common_parsers = common_parsers
+    del common_parsers  # Unused by this register method.
     parent_parsers = required_parsers
     parser = args_subparsers.add_parser(
         'init', description=CMD_DESCRIPTION, parents=parent_parsers)

--- a/snapshot_dbg_cli_tests/test_snapshot_debugger_rtdb_service.py
+++ b/snapshot_dbg_cli_tests/test_snapshot_debugger_rtdb_service.py
@@ -171,7 +171,7 @@ class SnapshotDebuggerRtdbServiceTests(unittest.TestCase):
     # cdbg/breakpoints/123/active/b-1650000000
     # cdbg/breakpoints/123/final/b-1650000000
     def get_response(path, shallow):
-      unused_shallow = shallow  # for pylint
+      del shallow  # Unused
       if 'active' in path and 'b-1650000000' in path:
         # Just need to return a snapshot to indicate the ID is not available.
         return SNAPSHOT_ACTIVE
@@ -204,7 +204,7 @@ class SnapshotDebuggerRtdbServiceTests(unittest.TestCase):
     # cdbg/breakpoints/123/active/b-1650000000
     # cdbg/breakpoints/123/final/b-1650000000
     def get_response(path, shallow):
-      unused_shallow = shallow  # for pylint
+      del shallow  # Unused
       if 'final' in path and 'b-1650000000' in path:
         # Just need to return a snapshot to indicate the ID is not available.
         return SNAPSHOT_ACTIVE


### PR DESCRIPTION
This is the recommended way by the Google python style guide for
suppressing pylint warnings about unused variables.