### PR TITLE
Add build/packaging support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__/
-env/
-dist/
 *.egg-info/
+dist/
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 env/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ they wish to maintain it going forward.
 See
 [COMMAND_REFERENCE.md](https://github.com/GoogleCloudPlatform/snapshot-debugger/blob/main/snapshot_dbg_cli/COMMAND_REFERENCE.md).
 
-## Download the Snapshot Debugger CLI
+## Installing the Snapshot Debugger CLI
 
-Clone the debugger to your local environment, or to your Cloud Shell
+Install the debugger cli in your local environment, or in your Cloud Shell
 $HOME directory. See [Using Cloud
 Shell](https://cloud.google.com/shell/docs/using-cloud-shell) for information on
 using Cloud Shell.
@@ -53,9 +53,8 @@ using Cloud Shell.
 Note: When using the Snapshot Debugger in Cloud Shell you will be asked to
 Authorize using your account credentials.
 
-1. Clone the Snapshot Debugger CLI
 ```
-git clone https://github.com/GoogleCloudPlatform/snapshot-debugger.git
+python3 -m pip install snapshot-dbg-cli
 ```
 
 ## Before you begin
@@ -174,7 +173,7 @@ Where PROJECT_ID is your project ID
 This will instruct the debugger CLI to create and use a database with the name
 `PROJECT_ID-cdbg`
 
-1. Run `python3 -m snapshot_dbg_cli init` in the cloned `snapshot-debugger`
+1. Run `snapshot-dbg-cli init` in the cloned `snapshot-debugger`
    directory.
 2. The output resembles the following:
 
@@ -194,8 +193,8 @@ commands.
 ```
 
 Note: The information printed by the `init` command can be accessed from within
-your Firebase project. It’s safe to run the `python3 -m snapshot_dbg_cli init`
-command multiple times to view this information.
+your Firebase project. It’s safe to run the `snapshot-dbg-cli init` command
+multiple times to view this information.
 
 #### Spark plan RTDB setup
 
@@ -203,7 +202,7 @@ This will instruct the CLI to create and use a database with the name
 `PROJECT_ID-default-rtdb`. It will only be created if it does not currently
 exist.
 
-1. Run `python3 -m snapshot_dbg_cli init --use-default-rtdb`
+1. Run `snapshot-dbg-cli init --use-default-rtdb`
 2. The output resembles the following:
 
 ```
@@ -222,7 +221,7 @@ commands.
 ```
 
 Note: The information printed by the `init` command can be accessed from within
-your Firebase project. It’s safe to run the `python3 -m snapshot_dbg_cli init
+your Firebase project. It’s safe to run the `snapshot-dbg-cli init
 --use-default-rtdb` command multiple times to view this information.
 
 ## Set up Snapshot Debugger in your Google Cloud project
@@ -332,7 +331,7 @@ directory unless otherwise specified.
 2. Run the following command
 
 ```
-python3 -m snapshot_dbg_cli list_debuggees
+snapshot-dbg-cli list_debuggees
 ```
 
 The output resembles the following:
@@ -354,7 +353,7 @@ return a snapshot of your app's data, and view it in detail to debug your app.
 2. Set snapshots with the following command:
 
 ```
-python3 -m snapshot_dbg_cli set_snapshot index.js:21 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f
+snapshot-dbg-cli set_snapshot index.js:21 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f
 ```
 
 Where:
@@ -377,7 +376,7 @@ command.
 
 Example:
 ```
-python3 -m snapshot_dbg_cli set_snapshot index.js:26 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --condition="ultimateAnswer <= 42 && foo==bar"
+snapshot-dbg-cli set_snapshot index.js:26 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --condition="ultimateAnswer <= 42 && foo==bar"
 ```
 
 You can use the following language features to express conditions:
@@ -416,7 +415,7 @@ command.
 
 Example:
 ```
-python3 -m snapshot_dbg_cli set_snapshot index.js:26 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --expression="histogram.length"
+snapshot-dbg-cli set_snapshot index.js:26 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --expression="histogram.length"
 ```
 
 
@@ -426,7 +425,7 @@ python3 -m snapshot_dbg_cli set_snapshot index.js:26 --debuggee-id 2054916c4b46c
 2. List snapshots with the following command:
 
 ```
-python3 -m snapshot_dbg_cli list_snapshots --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --include-inactive
+snapshot-dbg-cli list_snapshots --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --include-inactive
 ```
 
 Where:
@@ -449,7 +448,7 @@ COMPLETED  index.js:21               2022-03-23T02:52:23.558000Z  b-1648003845
 2. Get a snapshot with the following command:
 
 ```
-python3 -m snapshot_dbg_cli get_snapshot b-1649947203 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f
+snapshot-dbg-cli get_snapshot b-1649947203 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f
 ```
 
 Where:
@@ -508,7 +507,7 @@ Function              Location
 2. Delete snapshots with the following command:
 
 ```
-python3 -m snapshot_dbg_cli delete_snapshots --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --include-inactive
+snapshot-dbg-cli delete_snapshots --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --include-inactive
 ```
 
 Where:

--- a/README.md
+++ b/README.md
@@ -62,15 +62,7 @@ Authorize using your account credentials.
 
 There are two options to run the CLI once the pip install has been completed.
 
-### Option 1: Run the package directly
-
-Example running the `list_debuggees` command:
-
-```
-python3 -m snapshot_dbg_cli list_debuggees
-```
-
-### Option 2: Use the installed script
+### Option 1: Use the installed script
 
 As part of the pip install process, a script, `snapshot-dbg-cli` will be
 installed which can be used to run the CLI.
@@ -85,6 +77,14 @@ snapshot-dbg-cli list_debuggees
 script's install directory is in your PATH. Pip should emit a warning if the
 install location is not in the PATH, and also provide the install location in
 this case, so that you can add it to your PATH.
+
+### Option 2: Run the package directly
+
+Example running the `list_debuggees` command:
+
+```
+python3 -m snapshot_dbg_cli list_debuggees
+```
 
 
 ## Before you begin

--- a/README.md
+++ b/README.md
@@ -45,17 +45,47 @@ See
 
 ## Installing the Snapshot Debugger CLI
 
-Install the debugger cli in your local environment, or in your Cloud Shell
+Install the debugger CLI in your local environment, or in your Cloud Shell
 $HOME directory. See [Using Cloud
 Shell](https://cloud.google.com/shell/docs/using-cloud-shell) for information on
 using Cloud Shell.
 
-Note: When using the Snapshot Debugger in Cloud Shell you will be asked to
-Authorize using your account credentials.
-
 ```
 python3 -m pip install snapshot-dbg-cli
 ```
+
+> **Note**: When using the Snapshot Debugger in Cloud Shell you will be asked to
+Authorize using your account credentials.
+
+
+## Running the Snapshot Debugger CLI
+
+There are two options to run the CLI once the pip install has been completed.
+
+### Option 1: Run the package directly
+
+Example running the `list_debuggees` command:
+
+```
+python3 -m snapshot_dbg_cli list_debuggees
+```
+
+### Option 2: Use the installed script
+
+As part of the pip install process, a script, `snapshot-dbg-cli` will be
+installed which can be used to run the CLI.
+
+Example running the `list_debuggees` command:
+
+```
+snapshot-dbg-cli list_debuggees
+```
+
+> **NOTE**: To run the script this way from any directory, you must ensure the
+script's install directory is in your PATH. Pip should emit a warning if the
+install location is not in the PATH, and also provide the install location in
+this case, so that you can add it to your PATH.
+
 
 ## Before you begin
 
@@ -173,8 +203,7 @@ Where PROJECT_ID is your project ID
 This will instruct the debugger CLI to create and use a database with the name
 `PROJECT_ID-cdbg`
 
-1. Run `snapshot-dbg-cli init` in the cloned `snapshot-debugger`
-   directory.
+1. Run `snapshot-dbg-cli init`.
 2. The output resembles the following:
 
 ```
@@ -322,13 +351,9 @@ instances of the running application. In general all instances of the same
 version of the application will have the same debuggee ID, and breakpoints set
 on a debuggee will be installed on all running instances of it.
 
-The following workflow commands are run in the cloned `snapshot-debugger`
-directory unless otherwise specified.
-
 ### List Debuggees
 
-1. Navigate to the cloned `snapshot-debugger` directory
-2. Run the following command
+Run the following command
 
 ```
 snapshot-dbg-cli list_debuggees
@@ -349,8 +374,7 @@ Snapshots capture local variables and the call stack at a specific line location
 in your app's source code. You can specify certain conditions and locations to
 return a snapshot of your app's data, and view it in detail to debug your app.
 
-1. Navigate to the cloned `snapshot-debugger` directory
-2. Set snapshots with the following command:
+Set snapshots with the following command:
 
 ```
 snapshot-dbg-cli set_snapshot index.js:21 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f
@@ -421,8 +445,7 @@ snapshot-dbg-cli set_snapshot index.js:26 --debuggee-id 2054916c4b46c04e04fffa32
 
 ### List snapshots
 
-1. Navigate to the cloned `snapshot-debugger` directory
-2. List snapshots with the following command:
+List snapshots with the following command:
 
 ```
 snapshot-dbg-cli list_snapshots --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --include-inactive
@@ -444,8 +467,7 @@ COMPLETED  index.js:21               2022-03-23T02:52:23.558000Z  b-1648003845
 
 ### Get snapshot
 
-1. Navigate to the cloned `snapshot-debugger` directory
-2. Get a snapshot with the following command:
+Get a snapshot with the following command:
 
 ```
 snapshot-dbg-cli get_snapshot b-1649947203 --debuggee-id 2054916c4b46c04e04fffa32781bbd2f
@@ -503,8 +525,7 @@ Function              Location
 
 ### Delete snapshots
 
-1. Navigate to the cloned `snapshot-debugger` directory
-2. Delete snapshots with the following command:
+Delete snapshots with the following command:
 
 ```
 snapshot-dbg-cli delete_snapshots --debuggee-id 2054916c4b46c04e04fffa32781bbd2f --include-inactive

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,34 @@
+[metadata]
+name= snapshot-dbg-cli
+version = attr: snapshot_dbg_cli.__version__
+description='Snapshot Debugger CLI tool.'
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = Apache License, Version 2.0
+author = Google Inc.
+keywords = cloud, snapshot, debugger
+url = https://github.com/GoogleCloudPlatform/snapshot-debugger
+project_urls =
+  CLI Source = https://github.com/GoogleCloudPlatform/snapshot-debugger
+  Java Agent Source = https://github.com/GoogleCloudPlatform/cloud-debug-java
+  Node.js Agent Source = https://github.com/googleapis/cloud-debug-nodejs
+  Python Agent Source = https://github.com/GoogleCloudPlatform/cloud-debug-java
+
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Topic :: Software Development :: Debuggers
+
+[options]
+packages = snapshot_dbg_cli
+
+[options.entry_points]
+console_scripts =
+    snapshot-dbg-cli = snapshot_dbg_cli:run_main

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ license = Apache License, Version 2.0
 author = Google Inc.
 keywords = cloud, snapshot, debugger
 url = https://github.com/GoogleCloudPlatform/snapshot-debugger
+python_requires= >=3.6
 project_urls =
   CLI Source = https://github.com/GoogleCloudPlatform/snapshot-debugger
   Java Agent Source = https://github.com/GoogleCloudPlatform/cloud-debug-java

--- a/setup.py
+++ b/setup.py
@@ -11,30 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Snapshot Debugger CLI.
+"""Minimal setup.py file for packaging snapshot-dbg-cli.
 
-This package provides the CLI of the Snapshot Debugger.
+All packaging configuriation can be found in setup.cfg
 """
 
-import sys
-
-import snapshot_dbg_cli.cli_run
-from snapshot_dbg_cli.exceptions import SilentlyExitError
-
-__version__ = '0.1.0'
-
-
-def main():
-  snapshot_dbg_cli.cli_run.run()
-
-
-def run_main():
-  try:
-    main()
-  except SilentlyExitError:
-    sys.exit(1)
-
-  sys.exit(0)
+from setuptools import setup
 
 if __name__ == '__main__':
-  run_main()
+  setup()

--- a/snapshot_dbg_cli/COMMAND_REFERENCE.md
+++ b/snapshot_dbg_cli/COMMAND_REFERENCE.md
@@ -3,7 +3,7 @@
 ## init
 
 ```
-python3 -m snapshot_cdb_cli init
+snapshot-cdbg-cli init
 ```
 
 Usage: `__main__.py init [-h] [--use-default-rtdb] [--debug] [--database-id
@@ -27,7 +27,7 @@ perform a requested action and then rerun the command to make progress.
 ## list_debuggees
 
 ```
-python3 -m snapshot_cdb_cli list_debuggees
+snapshot-cdbg-cli list_debuggees
 ```
 
 
@@ -50,7 +50,7 @@ Snapshot Debugger.
 ## set_snapshot
 
 ```
-python3 -m snapshot_cdb_cli set_snapshot
+snapshot-cdbg-cli set_snapshot
 ```
 
 Usage: `__main__.py set_snapshot [-h] [--database-url DATABASE_URL]
@@ -87,7 +87,7 @@ again. It is also possible to inspect snapshot results with the
 ## list_snapshots
 
 ```
-python3 -m snapshot_cdb_cli list_snapshots
+snapshot-cdbg-cli list_snapshots
 ```
 
 
@@ -114,7 +114,7 @@ all active snapshots are returned. To obtain completed snapshots specify the
 ## get_snapshot
 
 ```
-python3 -m snapshot_cdb_cli get_snapshot
+snapshot-cdbg-cli get_snapshot
 ```
 
 Usage: `__main__.py get_snapshot [-h] [--database-url DATABASE_URL] [--format FORMAT]
@@ -152,7 +152,7 @@ form which is intended to be machine-readable rather than human-readable.
 ## delete_snapshots
 
 ```
-python3 -m snapshot_cdb_cli delete_snapshots
+snapshot-cdbg-cli delete_snapshots
 ```
 
 Usage: `__main__.py delete_snapshots [-h] [--database-url DATABASE_URL] [--format


### PR DESCRIPTION
Add setup.cfg and associated required changes to allow packaging the CLI.

This has been tested using TestPyPI.
- https://test.pypi.org/project/snapshot-dbg-cli/0.0.1/
- python3 -m pip install -i https://test.pypi.org/simple/ snapshot-dbg-cli

Fixes #60 