### PR TITLE
Include function `arguments` when parsing locals.

### DIFF
--- a/snapshot_dbg_cli/snapshot_parser.py
+++ b/snapshot_dbg_cli/snapshot_parser.py
@@ -73,9 +73,10 @@ class SnapshotParser:
   def parse_locals(self, stack_frame_index):
     local_variables = []
 
-    if stack_frame_index < len(
-        self.stack_frames) and 'locals' in self.stack_frames[stack_frame_index]:
-      local_variables = self.stack_frames[stack_frame_index]['locals']
+    if stack_frame_index < len(self.stack_frames):
+      stack_frame = self.stack_frames[stack_frame_index]
+      for p in ['arguments', 'locals']:
+        local_variables.extend(stack_frame.get(p, []))
 
     return self._resolve_variables(local_variables)
 


### PR DESCRIPTION
This change ensures the `get_snapshot` command will display the captured
data for variables classified as `arguments` for functions in the call
stack.

Fixes #61