### PR TITLE
feat: Add `delete_logpoints` command.

### DIFF
--- a/snapshot_dbg_cli/COMMAND_REFERENCE.md
+++ b/snapshot_dbg_cli/COMMAND_REFERENCE.md
@@ -168,7 +168,7 @@ confirmation before any snapshots are deleted. To suppress confirmation, use the
 
 | Arguments     | Description |
 |---------------|-------------|
-| `ID`          | Zero or more snapshot IDs. The specified snapshots will be deleted. By default, if no snapshot IDs are specified, all active snapshots created by the user are selected for deletion. |
+| `ID`          | Zero or more snapshot IDs. The specified snapshots will be deleted. By default, If no snapshot IDs are specified, all active snapshots created by the user are selected for deletion. |
 
 ### Optional arguments
 
@@ -182,40 +182,5 @@ confirmation before any snapshots are deleted. To suppress confirmation, use the
 | `--debug`                     | Enable CLI debug messages. |
 | ` --all-users`                | If set, snapshots from all users will be deleted, rather than only snapshots created by the current user. This flag is not required when specifying the exact ID of a snapshot. |
 | `--include-inactive`          | If set, also delete snapshots which have been completed. By default, only pending snapshots will be deleted. This flag is not required when specifying the exact ID of an inactive snapshot. |
-| `--quiet`                     | If set, suppresses user confirmation of the command. |
-
-## delete_logpoints
-
-```
-logpoint-cdbg-cli delete_logpoints
-```
-
-Usage: `__main__.py delete_logpoints [-h] [--database-url DATABASE_URL] [--format
-FORMAT] [--debug] [--all-users] [--include-inactive]
-[--quiet] [--debuggee-id DEBUGGEE_ID] [ID ...]`
-
-Used to delete logpoints from a debug target (debuggee). You are prompted for
-confirmation before any logpoints are deleted. To suppress confirmation, use the
---quiet option.
-
-
-### Positional arguments
-
-| Arguments     | Description |
-|---------------|-------------|
-| `ID`          | Zero or more logpoint IDs. The specified logpoints will be deleted. By default, if no logpoint IDs are specified, all active logpoints created by the user are selected for deletion. |
-
-### Optional arguments
-
-| Arguments                     | Description |
-|-------------------------------|-------------|
-| -h, --help                    | Show this help message and exit. |
-| `--include-inactive`          | Include completed logpoints. |
-| `--debuggee-id DEBUGGEE_ID`   | Specify the debuggee ID. It must be an ID obtained from the list_debuggees command. This value is required, it must be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DEBUGGEE_ID` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. It is only required if the `--database-id` argument was used with the init command.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
-| `--format FORMAT`             | Set the format for printing command output resources. The default is a command-specific human-friendly output format. The supported formats are: `default`, `json` (raw) and `pretty-json` (formatted `json`). |
-| `--debug`                     | Enable CLI debug messages. |
-| ` --all-users`                | If set, logpoints from all users will be deleted, rather than only logpoints created by the current user. This flag is not required when specifying the exact ID of a logpoint. |
-| `--include-inactive`          | If set, also delete logpoints which have been completed. By default, only pending logpoints will be deleted. This flag is not required when specifying the exact ID of an inactive logpoint. |
 | `--quiet`                     | If set, suppresses user confirmation of the command. |
 

--- a/snapshot_dbg_cli/COMMAND_REFERENCE.md
+++ b/snapshot_dbg_cli/COMMAND_REFERENCE.md
@@ -168,7 +168,7 @@ confirmation before any snapshots are deleted. To suppress confirmation, use the
 
 | Arguments     | Description |
 |---------------|-------------|
-| `ID`          | Zero or more snapshot IDs. The specified snapshots will be deleted. By default, If no snapshot IDs are specified, all active snapshots created by the user are selected for deletion. |
+| `ID`          | Zero or more snapshot IDs. The specified snapshots will be deleted. By default, if no snapshot IDs are specified, all active snapshots created by the user are selected for deletion. |
 
 ### Optional arguments
 
@@ -182,5 +182,40 @@ confirmation before any snapshots are deleted. To suppress confirmation, use the
 | `--debug`                     | Enable CLI debug messages. |
 | ` --all-users`                | If set, snapshots from all users will be deleted, rather than only snapshots created by the current user. This flag is not required when specifying the exact ID of a snapshot. |
 | `--include-inactive`          | If set, also delete snapshots which have been completed. By default, only pending snapshots will be deleted. This flag is not required when specifying the exact ID of an inactive snapshot. |
+| `--quiet`                     | If set, suppresses user confirmation of the command. |
+
+## delete_logpoints
+
+```
+logpoint-cdbg-cli delete_logpoints
+```
+
+Usage: `__main__.py delete_logpoints [-h] [--database-url DATABASE_URL] [--format
+FORMAT] [--debug] [--all-users] [--include-inactive]
+[--quiet] [--debuggee-id DEBUGGEE_ID] [ID ...]`
+
+Used to delete logpoints from a debug target (debuggee). You are prompted for
+confirmation before any logpoints are deleted. To suppress confirmation, use the
+--quiet option.
+
+
+### Positional arguments
+
+| Arguments     | Description |
+|---------------|-------------|
+| `ID`          | Zero or more logpoint IDs. The specified logpoints will be deleted. By default, if no logpoint IDs are specified, all active logpoints created by the user are selected for deletion. |
+
+### Optional arguments
+
+| Arguments                     | Description |
+|-------------------------------|-------------|
+| -h, --help                    | Show this help message and exit. |
+| `--include-inactive`          | Include completed logpoints. |
+| `--debuggee-id DEBUGGEE_ID`   | Specify the debuggee ID. It must be an ID obtained from the list_debuggees command. This value is required, it must be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DEBUGGEE_ID` environment variable.  When both are specified, the value from the command line takes precedence. |
+| `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. It is only required if the `--database-id` argument was used with the init command.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
+| `--format FORMAT`             | Set the format for printing command output resources. The default is a command-specific human-friendly output format. The supported formats are: `default`, `json` (raw) and `pretty-json` (formatted `json`). |
+| `--debug`                     | Enable CLI debug messages. |
+| ` --all-users`                | If set, logpoints from all users will be deleted, rather than only logpoints created by the current user. This flag is not required when specifying the exact ID of a logpoint. |
+| `--include-inactive`          | If set, also delete logpoints which have been completed. By default, only pending logpoints will be deleted. This flag is not required when specifying the exact ID of an inactive logpoint. |
 | `--quiet`                     | If set, suppresses user confirmation of the command. |
 

--- a/snapshot_dbg_cli/cli_run.py
+++ b/snapshot_dbg_cli/cli_run.py
@@ -23,6 +23,7 @@ import sys
 from snapshot_dbg_cli.cli_services import CliServices
 from snapshot_dbg_cli import cli_common_arguments
 from snapshot_dbg_cli.exceptions import SilentlyExitError
+from snapshot_dbg_cli.delete_logpoints_command import DeleteLogpointsCommand
 from snapshot_dbg_cli.delete_snapshots_command import DeleteSnapshotsCommand
 from snapshot_dbg_cli.get_snapshot_command import GetSnapshotCommand
 from snapshot_dbg_cli.init_command import InitCommand
@@ -33,6 +34,7 @@ from snapshot_dbg_cli.set_snapshot_command import SetSnapshotCommand
 
 def run(cli_services=None):
   cli_commands = [
+      DeleteLogpointsCommand(),
       DeleteSnapshotsCommand(),
       GetSnapshotCommand(),
       InitCommand(),

--- a/snapshot_dbg_cli/delete_breakpoints.py
+++ b/snapshot_dbg_cli/delete_breakpoints.py
@@ -1,0 +1,95 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module provides common functionality for delete breakpoints commands.
+
+Provides the command functionality for the delete_snapshots and delete_breakpoints commands.
+"""
+
+from snapshot_dbg_cli.exceptions import SilentlyExitError
+
+def run_cmd(action, args, cli_services, summary_headers, summary_transform):
+  """Contains the common logic to run a delete snapshots or logpoints command.
+
+  Args:
+    action: A string matching the action from breakpoints, either 'CAPTURE' (for
+      snapshots) or 'LOG' (for logpoints).
+    args: The argsparse args for the delete command.
+    cli_services: The CliServices instance to use for running the command.
+    summary_headers: The headers for the breakpoints table the delete command emits for the user
+  Returns:
+    string, [string]) - The new format string and the array of expressions.
+  Raises:
+    Error: If the string has unbalanced braces.
+  """
+  # This two variables provide customization for emitted user messages.
+  breakpoint_type = 'snapshot' if action == 'CAPTURE' else 'logpoint'
+  breakpoint_type_capitalized = breakpoint_type[0].upper() + breakpoint_type[1:]
+
+
+  user_input = cli_services.user_input
+  user_output = cli_services.user_output
+  debugger_rtdb_service = cli_services.get_snapshot_debugger_rtdb_service()
+
+  debugger_rtdb_service.validate_debuggee_id(args.debuggee_id)
+
+  # This will be a list, if no IDs were specified it will be empty. If any IDs
+  # are specified those are the only ones that will be deleted.
+  breakpoint_ids = args.ID
+
+  user_email = None if args.all_users is True else cli_services.account
+
+  breakpoints = []
+
+  if breakpoint_ids:
+    ids_not_found = []
+
+    for bp_id in breakpoint_ids:
+      bp = debugger_rtdb_service.get_breakpoint(args.debuggee_id, bp_id)
+      if bp is None or bp['action'] != action:
+        ids_not_found.append(bp_id)
+      else:
+        breakpoints.append(bp)
+
+    if ids_not_found:
+      user_output.error(f"{breakpoint_type_capitalized} ID not found: {', '.join(ids_not_found)}")
+      raise SilentlyExitError
+  else:
+    if action == 'CAPTURE':
+      breakpoints = debugger_rtdb_service.get_snapshots(args.debuggee_id,
+                                                        args.include_inactive,
+                                                        user_email)
+    else:
+      breakpoints = debugger_rtdb_service.get_logpoints(args.debuggee_id,
+                                                        args.include_inactive,
+                                                        user_email)
+
+  if breakpoints:
+    user_output.normal(f'This command will delete the following {breakpoint_type}s:\n')
+    values = list(map(summary_transform, breakpoints))
+    user_output.tabular(summary_headers, values)
+    user_output.normal('\n')
+
+    if not args.quiet and not user_input.prompt_user_to_continue():
+      user_output.error('Delete aborted.')
+      return
+
+    debugger_rtdb_service.delete_breakpoints(args.debuggee_id, breakpoints)
+
+  # The status is output regardless of the requested output format. It should
+  # go to stderr, and if json output is requested, that should end up on
+  # stdout.
+  user_output.normal(f'Deleted {len(breakpoints)} {breakpoint_type}s.')
+
+  if args.format.is_a_json_value():
+    user_output.json_format(breakpoints, pretty=args.format.is_pretty_json())

--- a/snapshot_dbg_cli/delete_breakpoints.py
+++ b/snapshot_dbg_cli/delete_breakpoints.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """This module provides common functionality for delete breakpoints commands.
 
-Provides the command functionality for the delete_snapshots and delete_breakpoints commands.
+Provides the command functionality for the delete_snapshots and
+delete_breakpoints commands.
 """
 
 from snapshot_dbg_cli.exceptions import SilentlyExitError
+
 
 def run_cmd(action, args, cli_services, summary_headers, summary_transform):
   """Contains the common logic to run a delete snapshots or logpoints command.
@@ -26,7 +28,8 @@ def run_cmd(action, args, cli_services, summary_headers, summary_transform):
       snapshots) or 'LOG' (for logpoints).
     args: The argsparse args for the delete command.
     cli_services: The CliServices instance to use for running the command.
-    summary_headers: The headers for the breakpoints table the delete command emits for the user
+    summary_headers: The headers for the breakpoints table the delete command
+      emits for the user.
   Returns:
     string, [string]) - The new format string and the array of expressions.
   Raises:
@@ -35,7 +38,6 @@ def run_cmd(action, args, cli_services, summary_headers, summary_transform):
   # This two variables provide customization for emitted user messages.
   breakpoint_type = 'snapshot' if action == 'CAPTURE' else 'logpoint'
   breakpoint_type_capitalized = breakpoint_type[0].upper() + breakpoint_type[1:]
-
 
   user_input = cli_services.user_input
   user_output = cli_services.user_output
@@ -62,7 +64,8 @@ def run_cmd(action, args, cli_services, summary_headers, summary_transform):
         breakpoints.append(bp)
 
     if ids_not_found:
-      user_output.error(f"{breakpoint_type_capitalized} ID not found: {', '.join(ids_not_found)}")
+      user_output.error(f'{breakpoint_type_capitalized} ID not found: '
+                        f"{', '.join(ids_not_found)}")
       raise SilentlyExitError
   else:
     if action == 'CAPTURE':
@@ -75,7 +78,8 @@ def run_cmd(action, args, cli_services, summary_headers, summary_transform):
                                                         user_email)
 
   if breakpoints:
-    user_output.normal(f'This command will delete the following {breakpoint_type}s:\n')
+    user_output.normal(
+        f'This command will delete the following {breakpoint_type}s:\n')
     values = list(map(summary_transform, breakpoints))
     user_output.tabular(summary_headers, values)
     user_output.normal('\n')

--- a/snapshot_dbg_cli/delete_logpoints_command.py
+++ b/snapshot_dbg_cli/delete_logpoints_command.py
@@ -89,4 +89,5 @@ class DeleteLogpointsCommand:
     parser.set_defaults(func=self.cmd)
 
   def cmd(self, args, cli_services):
-    delete_breakpoints.run_cmd('LOG', args, cli_services, SUMMARY_HEADERS, transform_to_logpoint_summary)
+    delete_breakpoints.run_cmd('LOG', args, cli_services, SUMMARY_HEADERS,
+                               transform_to_logpoint_summary)

--- a/snapshot_dbg_cli/delete_logpoints_command.py
+++ b/snapshot_dbg_cli/delete_logpoints_command.py
@@ -17,8 +17,8 @@ The delete_logpoints command is used to delete logpoints from a debug target
 (debuggee).
 """
 
-from snapshot_dbg_cli.exceptions import SilentlyExitError
 from snapshot_dbg_cli import breakpoint_utils
+from snapshot_dbg_cli import delete_breakpoints
 
 DESCRIPTION = """
 Used to delete logpoints from a debug target (debuggee). You are prompted for
@@ -89,54 +89,4 @@ class DeleteLogpointsCommand:
     parser.set_defaults(func=self.cmd)
 
   def cmd(self, args, cli_services):
-    user_input = cli_services.user_input
-    user_output = cli_services.user_output
-    debugger_rtdb_service = cli_services.get_snapshot_debugger_rtdb_service()
-
-    debugger_rtdb_service.validate_debuggee_id(args.debuggee_id)
-
-    # This will be a list, if no IDs were specified it will be empty. If any IDs
-    # are specified those are the only ones that will be deleted.
-    logpoint_ids = args.ID
-
-    user_email = None if args.all_users is True else cli_services.account
-
-    logpoints = []
-
-    if logpoint_ids:
-      ids_not_found = []
-
-      for bp_id in logpoint_ids:
-        logpoint = debugger_rtdb_service.get_breakpoint(args.debuggee_id, bp_id)
-        if logpoint is None or logpoint['action'] != 'LOG':
-          ids_not_found.append(bp_id)
-        else:
-          logpoints.append(logpoint)
-
-      if ids_not_found:
-        user_output.error(f"Logpoint ID not found: {', '.join(ids_not_found)}")
-        raise SilentlyExitError
-    else:
-      logpoints = debugger_rtdb_service.get_logpoints(args.debuggee_id,
-                                                      args.include_inactive,
-                                                      user_email)
-
-    if logpoints:
-      user_output.normal('This command will delete the following logpoints:\n')
-      values = list(map(transform_to_logpoint_summary, logpoints))
-      user_output.tabular(SUMMARY_HEADERS, values)
-      user_output.normal('\n')
-
-      if not args.quiet and not user_input.prompt_user_to_continue():
-        user_output.error('Delete aborted.')
-        return
-
-      debugger_rtdb_service.delete_breakpoints(args.debuggee_id, logpoints)
-
-    # The status is output regardless of the requested output format. It should
-    # go to stderr, and if json output is requested, that should end up on
-    # stdout.
-    user_output.normal(f'Deleted {len(logpoints)} logpoints.')
-
-    if args.format.is_a_json_value():
-      user_output.json_format(logpoints, pretty=args.format.is_pretty_json())
+    delete_breakpoints.run_cmd('LOG', args, cli_services, SUMMARY_HEADERS, transform_to_logpoint_summary)

--- a/snapshot_dbg_cli/delete_snapshots_command.py
+++ b/snapshot_dbg_cli/delete_snapshots_command.py
@@ -85,4 +85,5 @@ class DeleteSnapshotsCommand:
     parser.set_defaults(func=self.cmd)
 
   def cmd(self, args, cli_services):
-    delete_breakpoints.run_cmd('CAPTURE', args, cli_services, SUMMARY_HEADERS, transform_to_snapshot_summary)
+    delete_breakpoints.run_cmd('CAPTURE', args, cli_services, SUMMARY_HEADERS,
+                               transform_to_snapshot_summary)

--- a/snapshot_dbg_cli_tests/test_cli_run.py
+++ b/snapshot_dbg_cli_tests/test_cli_run.py
@@ -36,6 +36,7 @@ class CliRunTests(unittest.TestCase):
 
   def test_expected_commands_are_registered(self):
     testcases = [
+        ('delete_logpoints', 'Used to delete logpoints'),
         ('delete_snapshots', 'Used to delete snapshots'),
         ('get_snapshot', 'Used to retrieve a debug snapshot'),
         ('init', 'Initializes a GCP project with the required'),

--- a/snapshot_dbg_cli_tests/test_delete_logpoints_command.py
+++ b/snapshot_dbg_cli_tests/test_delete_logpoints_command.py
@@ -1,0 +1,450 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Unit test file for the DeleteLogpointsCommand class.
+"""
+import copy
+import json
+import os
+import sys
+import unittest
+
+from snapshot_dbg_cli import cli_run
+from snapshot_dbg_cli import data_formatter
+from snapshot_dbg_cli.cli_services import CliServices
+from snapshot_dbg_cli.exceptions import SilentlyExitError
+from snapshot_dbg_cli.snapshot_debugger_rtdb_service import SnapshotDebuggerRtdbService
+from snapshot_dbg_cli.user_input import UserInput
+from snapshot_dbg_cli.user_output import UserOutput
+
+from io import StringIO
+from unittest.mock import ANY
+from unittest.mock import call
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+LOGPOINT_ACTIVE =  {
+  'action': 'LOG',
+  'logMessageFormat': 'a: $0',
+  'expressions': ['a'],
+  'logMessageFormatString': 'a: {a}',
+  'logLevel': 'INFO',
+  'createTimeUnixMsec': 1649962215426,
+  'id': 'b-1649962215',
+  'isFinalState': False,
+  'location': {'line': 26, 'path': 'index.js'},
+  'userEmail': 'user_a@foo.com',
+  'createTime': '2022-04-14T18:50:15.852000Z',
+} # yapf: disable (Subjectively, more readable hand formatted)
+
+LOGPOINT_WITH_CONDITION =  {
+  'action': 'LOG',
+  'logMessageFormat': 'b: $0',
+  'expressions': ['b'],
+  'logMessageFormatString': 'b: {b}',
+  'logLevel': 'WARNING',
+  'createTimeUnixMsec': 1649962216426,
+  'condition': 'a == 3',
+  'id': 'b-1649962216',
+  'isFinalState': False,
+  'location': {'line': 27, 'path': 'index.js'},
+  'userEmail': 'user_b@foo.com',
+  'createTime': '2022-04-14T18:50:16.852000Z',
+} # yapf: disable (Subjectively, more readable hand formatted)
+
+LOGPOINT_EXPIRED =  {
+  'action': 'LOG',
+  'logMessageFormat': 'c: $0',
+  'expressions': ['c'],
+  'logMessageFormatString': 'c: {c}',
+  'logLevel': 'ERROR',
+  'id': 'b-1649962217',
+  'createTimeUnixMsec': 1649962217426,
+  'isFinalState': True,
+  'location': {'line': 28, 'path': 'index.js'},
+  'userEmail': 'user_c@foo.com',
+  'createTime': '2022-04-14T18:50:17.852000Z',
+  'finalTime': '2022-04-14T18:50:31.274000Z',
+  'status': {
+    'description': {
+      'format': 'The logpoint has expired'
+    },
+    'isError': True,
+    'refersTo': 'BREAKPOINT_AGE'
+  },
+} # yapf: disable (Subjectively, more readable hand formatted)
+
+SNAPSHOT_ACTIVE =  {
+  'action': 'CAPTURE',
+  'createTimeUnixMsec': 1649962215426,
+  'id': 'b-1650000000',
+  'isFinalState': False,
+  'location': {'line': 26, 'path': 'index.js'},
+  'userEmail': 'user@foo.com',
+  'createTime': '2022-04-14T18:50:15.852000Z',
+} # yapf: disable (Subjectively, more readable hand formatted)
+
+class DeleteLogpointsCommandTests(unittest.TestCase):
+  """ Contains the unit tests for the DeleteLogpointsCommand class.
+  """
+
+  def setUp(self):
+    self.cli_services = MagicMock(spec=CliServices)
+
+    self.user_input_mock = MagicMock(spec=UserInput)
+    self.cli_services.user_input = self.user_input_mock
+
+    self.data_formatter = data_formatter.DataFormatter()
+    self.cli_services.data_formatter = self.data_formatter
+
+    self.user_output_mock = MagicMock(
+        wraps=UserOutput(
+            is_debug_enabled=False,
+            data_formatter=data_formatter.DataFormatter()))
+    self.cli_services.user_output = self.user_output_mock
+
+    self.rtdb_service_mock = MagicMock(spec=SnapshotDebuggerRtdbService)
+    self.cli_services.get_snapshot_debugger_rtdb_service = MagicMock(
+        return_value=self.rtdb_service_mock)
+
+    # Just setup some sane defaults. Tests that care about these values and need
+    # different behaviour will simply overrite as needed.
+    self.cli_services.account = 'foo@bar.com'
+    self.user_input_mock.prompt_user_to_continue = MagicMock(return_value=True)
+    self.rtdb_service_mock.get_breakpoint = MagicMock(return_value=None)
+    self.rtdb_service_mock.get_logpoints = MagicMock(return_value=[])
+
+  def run_cmd(self, testargs, expected_exception=None):
+    args = ['cli-test', 'delete_logpoints'] + testargs
+
+    # We patch os.environ as some cli arguments can come from environment
+    # variables, and if they happen to be set in the terminal running the tests
+    # it will affect things.
+    with patch.object(sys, 'argv', args), \
+         patch.dict(os.environ, {}, clear=True), \
+         patch('sys.stdout', new_callable=StringIO) as out, \
+         patch('sys.stderr', new_callable=StringIO) as err:
+      if expected_exception is not None:
+        with self.assertRaises(expected_exception):
+          cli_run.run(self.cli_services)
+      else:
+        cli_run.run(self.cli_services)
+
+    return out, err
+
+  def test_debuggee_id_is_required(self):
+    testargs = []
+
+    # debuggee-id should be a required parameter, the argparse library should
+    # enforce this and use SystemExit if it's not found.
+    out, err = self.run_cmd(testargs, expected_exception=SystemExit)
+
+    self.assertIn('error: the following arguments are required: --debuggee-id',
+                  err.getvalue())
+    self.assertEqual('', out.getvalue())
+
+  def test_validate_debuggee_id_called_as_expected(self):
+    testargs = ['--debuggee-id=123']
+    self.rtdb_service_mock.validate_debuggee_id = MagicMock(
+        side_effect=SilentlyExitError())
+
+    self.run_cmd(testargs, expected_exception=SilentlyExitError)
+
+    self.rtdb_service_mock.validate_debuggee_id.assert_called_once_with('123')
+    self.rtdb_service_mock.delete_breakpoints.assert_not_called()
+
+  def test_one_id_specified_and_exists_gets_deleted(self):
+    testargs = ['--debuggee-id=123', 'b-1649962215']
+
+    self.rtdb_service_mock.get_breakpoint = MagicMock(
+        return_value=LOGPOINT_ACTIVE)
+
+    self.run_cmd(testargs)
+
+    self.rtdb_service_mock.get_breakpoint.assert_called_once_with(
+        '123', 'b-1649962215')
+    self.rtdb_service_mock.delete_breakpoints.assert_called_once_with(
+        '123', [LOGPOINT_ACTIVE])
+
+  def test_multiple_ids_specified_and_exist_get_deleted(self):
+    testargs = [
+        '--debuggee-id=123', 'b-1649962215', 'b-1649962216', 'b-1649962217'
+    ]
+
+    self.rtdb_service_mock.get_breakpoint = MagicMock(side_effect=[
+        LOGPOINT_ACTIVE, LOGPOINT_WITH_CONDITION, LOGPOINT_EXPIRED
+    ])
+
+    self.run_cmd(testargs)
+
+    self.assertEqual([
+        call('123', 'b-1649962215'),
+        call('123', 'b-1649962216'),
+        call('123', 'b-1649962217')
+    ], self.rtdb_service_mock.get_breakpoint.mock_calls)
+
+    self.rtdb_service_mock.delete_breakpoints.assert_called_once_with(
+        '123', [LOGPOINT_ACTIVE, LOGPOINT_WITH_CONDITION, LOGPOINT_EXPIRED])
+
+  def test_one_id_specified_and_not_found(self):
+    testargs = ['--debuggee-id=123', 'b-1650000001']
+
+    self.rtdb_service_mock.get_breakpoint = MagicMock(return_value=None)
+
+    out, err = self.run_cmd(testargs, expected_exception=SilentlyExitError)
+
+    self.rtdb_service_mock.get_breakpoint.assert_called_once_with(
+        '123', 'b-1650000001')
+    self.rtdb_service_mock.delete_breakpoints.assert_not_called()
+    self.assertEqual('Logpoint ID not found: b-1650000001\n', err.getvalue())
+    self.assertEqual('', out.getvalue())
+
+  def test_id_specified_matches_snapshot_and_not_logpoint(self):
+    """Verifies users can't delete snapshots through this command.
+    """
+    testargs = ['--debuggee-id=123', 'b-1650000000']
+
+    self.rtdb_service_mock.get_breakpoint = MagicMock(
+        return_value=SNAPSHOT_ACTIVE)
+
+    out, err = self.run_cmd(testargs, expected_exception=SilentlyExitError)
+
+    self.rtdb_service_mock.get_breakpoint.assert_called_once_with(
+        '123', 'b-1650000000')
+    self.rtdb_service_mock.delete_breakpoints.assert_not_called()
+    self.assertEqual('Logpoint ID not found: b-1650000000\n', err.getvalue())
+    self.assertEqual('', out.getvalue())
+
+  def test_multiple_ids_specified_and_some_not_found(self):
+    testargs = [
+        '--debuggee-id=123', 'b-1650000000', 'b-1650000001', 'b-1650000002'
+    ]
+
+    self.rtdb_service_mock.get_breakpoint = MagicMock(
+        side_effect=[None, LOGPOINT_WITH_CONDITION, None])
+
+    out, err = self.run_cmd(testargs, expected_exception=SilentlyExitError)
+
+    self.rtdb_service_mock.delete_breakpoints.assert_not_called()
+    self.assertEqual('Logpoint ID not found: b-1650000000, b-1650000002\n',
+                     err.getvalue())
+    self.assertEqual('', out.getvalue())
+
+  def test_queried_logpoints_uses_correct_debuggee_id(self):
+    testargs = ['--debuggee-id=123']
+
+    self.run_cmd(testargs)
+
+    self.rtdb_service_mock.get_logpoints.assert_called_once_with(
+        '123', ANY, ANY)
+
+  def test_queried_logpoints_uses_correct_include_inactive(self):
+    testcases = [
+        # (Test name, testargs, expected include_inactive)
+        ('Default Active Only', ['--debuggee-id=123'], False),
+        ('Incude Inactive', ['--debuggee-id=123', '--include-inactive'], True),
+    ]
+
+    for test_name, testargs, expected_include_inactive in testcases:
+      with self.subTest(test_name):
+        self.rtdb_service_mock.reset_mock()
+        self.run_cmd(testargs)
+        self.rtdb_service_mock.get_logpoints.assert_called_once_with(
+            ANY, expected_include_inactive, ANY)
+
+  def test_queried_logpoints_uses_correct_account(self):
+    self.cli_services.account = 'cli-test@foo.com'
+
+    testcases = [
+        # (Test name, testargs, expected include_inactive)
+        ('Default User Only', ['--debuggee-id=123'], 'cli-test@foo.com'),
+        ('All Users', ['--debuggee-id=123', '--all-users'], None),
+    ]
+
+    for test_name, testargs, expected_user_email in testcases:
+      with self.subTest(test_name):
+        self.rtdb_service_mock.reset_mock()
+        self.run_cmd(testargs)
+        self.rtdb_service_mock.get_logpoints.assert_called_once_with(
+            ANY, ANY, expected_user_email)
+
+  def test_user_prompted_with_logpoint_summary_before_delete(self):
+    testargs = ['--debuggee-id=123']
+
+    logpoint_without_condition = copy.deepcopy(LOGPOINT_ACTIVE)
+    self.assertNotIn('condition', logpoint_without_condition)
+
+    logpoint_info_level = copy.deepcopy(LOGPOINT_ACTIVE)
+    logpoint_info_level['logLevel'] = 'INFO'
+
+    logpoint_warning_level = copy.deepcopy(LOGPOINT_ACTIVE)
+    logpoint_warning_level['logLevel'] = 'WARNING'
+
+    logpoint_error_level = copy.deepcopy(LOGPOINT_ACTIVE)
+    logpoint_error_level['logLevel'] = 'ERROR'
+
+    expected_active_row = ['index.js:26', '', 'INFO', 'a: {a}', 'b-1649962215']
+    expected_without_condition_row = [
+        'index.js:26', '', 'INFO', 'a: {a}', 'b-1649962215'
+    ]
+    expected_info_level_row = [
+        'index.js:26', '', 'INFO', 'a: {a}', 'b-1649962215'
+    ]
+    expected_warning_level_row = [
+        'index.js:26', '', 'WARNING', 'a: {a}', 'b-1649962215'
+    ]
+    expected_error_level_row = [
+        'index.js:26', '', 'ERROR', 'a: {a}', 'b-1649962215'
+    ]
+    expected_with_condition_row = [
+        'index.js:27', 'a == 3', 'WARNING', 'b: {b}', 'b-1649962216'
+    ]
+    expected_expired_row = [
+        'index.js:28', '', 'ERROR', 'c: {c}', 'b-1649962217'
+    ]
+
+    testcases = [
+        ('Without Condition', [logpoint_without_condition],
+         [expected_without_condition_row]),
+        ('With Condition', [LOGPOINT_WITH_CONDITION],
+         [expected_with_condition_row]),
+        ('Info Level', [logpoint_info_level], [expected_info_level_row]),
+        ('Warning Level', [logpoint_warning_level],
+         [expected_warning_level_row]),
+        ('Error Level', [logpoint_error_level], [expected_error_level_row]),
+        ('Multiple',
+         [LOGPOINT_ACTIVE, LOGPOINT_WITH_CONDITION, LOGPOINT_EXPIRED], [
+             expected_active_row, expected_with_condition_row,
+             expected_expired_row
+         ])
+    ]
+
+    for test_name, logpoints, expected_rows in testcases:
+      with self.subTest(test_name):
+        self.user_input_mock.reset_mock()
+        self.user_output_mock.reset_mock()
+
+        self.rtdb_service_mock.get_logpoints = MagicMock(return_value=logpoints)
+        self.run_cmd(testargs)
+
+        self.user_output_mock.normal.assert_any_call(
+            'This command will delete the following logpoints:\n')
+        self.user_output_mock.tabular.assert_called_with(
+            ['Location', 'Condition', 'Log Level', 'Log Message Format', 'ID'],
+            expected_rows)
+
+        self.user_input_mock.prompt_user_to_continue.assert_called_once()
+
+  def test_user_prompted_before_delete_answers_no(self):
+    testargs = ['--debuggee-id=123']
+    self.rtdb_service_mock.get_logpoints = MagicMock(
+        return_value=[LOGPOINT_ACTIVE])
+
+    # Returning False means user said no.
+    self.user_input_mock.prompt_user_to_continue = MagicMock(return_value=False)
+
+    self.run_cmd(testargs)
+
+    self.rtdb_service_mock.delete_breakpoints.assert_not_called()
+    self.user_input_mock.prompt_user_to_continue.assert_called_once()
+
+  def test_user_prompted_before_delete_answers_yes(self):
+    testargs = ['--debuggee-id=123']
+    self.rtdb_service_mock.get_logpoints = MagicMock(
+        return_value=[LOGPOINT_ACTIVE])
+    self.user_input_mock.prompt_user_to_continue = MagicMock(return_value=True)
+
+    self.run_cmd(testargs)
+
+    self.rtdb_service_mock.delete_breakpoints.assert_called_once()
+    self.user_input_mock.prompt_user_to_continue.assert_called_once()
+
+  def test_user_uses_quiet_mode_to_avoid_prompt(self):
+    testargs = ['--debuggee-id=123', '--quiet']
+    self.rtdb_service_mock.get_logpoints = MagicMock(
+        return_value=[LOGPOINT_ACTIVE])
+    self.run_cmd(testargs)
+
+    self.rtdb_service_mock.delete_breakpoints.assert_called_once()
+    self.user_input_mock.prompt_user_to_continue.assert_not_called()
+
+  def test_no_logpoints_found_delete_not_called(self):
+    testargs = ['--debuggee-id=123', '--quiet']
+    self.rtdb_service_mock.get_logpoints = MagicMock(return_value=[])
+    self.run_cmd(testargs)
+
+    self.user_input_mock.prompt_user_to_continue.assert_not_called()
+    self.rtdb_service_mock.delete_breakpoints.assert_not_called()
+    self.rtdb_service_mock.get_logpoints.assert_called_once()
+
+  def test_delete_results_output_format_default(self):
+    testargs = ['--debuggee-id=123']
+
+    testcases = [('No Logpoints', [], 0),
+                 ('One Logpoint', [LOGPOINT_ACTIVE], 1),
+                 ('Multiple Logpoints',
+                  [LOGPOINT_ACTIVE, LOGPOINT_WITH_CONDITION,
+                   LOGPOINT_EXPIRED], 3)]
+
+    for test_name, logpoints, expected_deleted_count in testcases:
+      with self.subTest(test_name):
+        self.rtdb_service_mock.get_logpoints = MagicMock(return_value=logpoints)
+        out, err = self.run_cmd(testargs)
+
+        self.assertIn(f'Deleted {expected_deleted_count} logpoints',
+                      err.getvalue())
+        self.assertEqual('', out.getvalue())
+
+  def test_delete_results_output_format_json(self):
+    testargs = ['--debuggee-id=123', '--format=json']
+
+    testcases = [('No Logpoints', [], 0),
+                 ('One Logpoint', [LOGPOINT_ACTIVE], 1),
+                 ('Multiple Logpoints',
+                  [LOGPOINT_ACTIVE, LOGPOINT_WITH_CONDITION,
+                   LOGPOINT_EXPIRED], 3)]
+
+    for test_name, logpoints, expected_deleted_count in testcases:
+      with self.subTest(test_name):
+        self.user_output_mock.reset_mock()
+
+        self.rtdb_service_mock.get_logpoints = MagicMock(return_value=logpoints)
+        out, err = self.run_cmd(testargs)
+
+        self.user_output_mock.json_format.assert_called_once_with(
+            logpoints, pretty=False)
+        self.assertIn(f'Deleted {expected_deleted_count} logpoints',
+                      err.getvalue())
+        self.assertEqual(logpoints, json.loads(out.getvalue()))
+
+  def test_delete_results_output_format_pretty_json(self):
+    testargs = ['--debuggee-id=123', '--format=pretty-json']
+
+    testcases = [('No Logpoints', [], 0),
+                 ('One Logpoint', [LOGPOINT_ACTIVE], 1),
+                 ('Multiple Logpoints',
+                  [LOGPOINT_ACTIVE, LOGPOINT_WITH_CONDITION,
+                   LOGPOINT_EXPIRED], 3)]
+
+    for test_name, logpoints, expected_deleted_count in testcases:
+      with self.subTest(test_name):
+        self.user_output_mock.reset_mock()
+
+        self.rtdb_service_mock.get_logpoints = MagicMock(return_value=logpoints)
+        out, err = self.run_cmd(testargs)
+
+        self.user_output_mock.json_format.assert_called_once_with(
+            logpoints, pretty=True)
+        self.assertIn(f'Deleted {expected_deleted_count} logpoints',
+                      err.getvalue())
+        self.assertEqual(logpoints, json.loads(out.getvalue()))

--- a/snapshot_dbg_cli_tests/test_delete_snapshots_command.py
+++ b/snapshot_dbg_cli_tests/test_delete_snapshots_command.py
@@ -65,6 +65,20 @@ SNAPSHOT_COMPLETED =  {
   'createTime': '2022-04-14T18:50:15.852000Z',
 } # yapf: disable (Subjectively, more readable hand formatted)
 
+LOGPOINT_ACTIVE =  {
+  'action': 'LOG',
+  'logMessageFormat': 'a: $0',
+  'expressions': ['a'],
+  'logMessageFormatString': 'a: {a}',
+  'logLevel': 'INFO',
+  'createTimeUnixMsec': 1649962215426,
+  'id': 'b-1649962215',
+  'isFinalState': False,
+  'location': {'line': 26, 'path': 'index.js'},
+  'userEmail': 'user_a@foo.com',
+  'createTime': '2022-04-14T18:50:15.852000Z',
+} # yapf: disable (Subjectively, more readable hand formatted)
+
 class DeleteSnapshotsCommandTests(unittest.TestCase):
   """ Contains the unit tests for the DeleteSnapshotsCommand class.
   """
@@ -146,6 +160,22 @@ class DeleteSnapshotsCommandTests(unittest.TestCase):
         '123', 'b-1650000000')
     self.rtdb_service_mock.delete_breakpoints.assert_called_once_with(
         '123', [SNAPSHOT_ACTIVE])
+
+  def test_id_specified_matches_logpoint_and_not_snapshot(self):
+    """Verifies users can't delete logpoints through this command.
+    """
+    testargs = ['--debuggee-id=123', 'b-1649962215']
+
+    self.rtdb_service_mock.get_breakpoint = MagicMock(
+        return_value=LOGPOINT_ACTIVE)
+
+    out, err = self.run_cmd(testargs, expected_exception=SilentlyExitError)
+
+    self.rtdb_service_mock.get_breakpoint.assert_called_once_with(
+        '123', 'b-1649962215')
+    self.rtdb_service_mock.delete_breakpoints.assert_not_called()
+    self.assertEqual('Snapshot ID not found: b-1649962215\n', err.getvalue())
+    self.assertEqual('', out.getvalue())
 
   def test_multiple_ids_specified_and_exist_get_deleted(self):
     testargs = [


### PR DESCRIPTION
To note, this change is dependent on #70, requiring the changes to [breakpoint_utils.py](https://github.com/GoogleCloudPlatform/snapshot-debugger/pull/70/files#diff-fbb1e002e858866b5dcb4f8fef9a8982d0ee60361cbdc74dd862aff0402abd62) and [snapshot_debugger_rtdb_service.py](https://github.com/GoogleCloudPlatform/snapshot-debugger/pull/70/files#diff-ef8744b8574033c0cdbd967ee979c8d7d8e1d498923cbe52e908cb01ab3e7863).