### PR TITLE
chore: Bump version to 0.2.0.

### DIFF
--- a/snapshot_dbg_cli/__init__.py
+++ b/snapshot_dbg_cli/__init__.py
@@ -21,7 +21,7 @@ import sys
 import snapshot_dbg_cli.cli_run
 from snapshot_dbg_cli.exceptions import SilentlyExitError
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 
 
 def main():

--- a/snapshot_dbg_cli/cli_version.py
+++ b/snapshot_dbg_cli/cli_version.py
@@ -22,7 +22,7 @@ from snapshot_dbg_cli.exceptions import SilentlyExitError
 from snapshot_dbg_cli.http_service import HttpService
 from snapshot_dbg_cli.user_output import UserOutput
 
-VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_1_1'
+VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_2_0'
 
 VERSION_PATTERN = 'SNAPSHOT_DEBUGGER_CLI_VERSION_[0-9]+_[0-9]+_[0-9]+'
 

--- a/snapshot_dbg_cli_tests/test_init.py
+++ b/snapshot_dbg_cli_tests/test_init.py
@@ -24,4 +24,4 @@ class CliInitTests(unittest.TestCase):
 
   def test_version_is_expected_value(self):
     # Yes, this will need to be updated for each new version.
-    self.assertEqual('0.1.1', snapshot_dbg_cli.__version__)
+    self.assertEqual('0.2.0', snapshot_dbg_cli.__version__)


### PR DESCRIPTION
This is a minor version bump to account for the support of the logpoint commands.