### PR TITLE
chore: Remove service simple server

### DIFF
--- a/samples/java/appengine-java11/simple-server/README.md
+++ b/samples/java/appengine-java11/simple-server/README.md
@@ -35,7 +35,7 @@ wget -qO- https://github.com/GoogleCloudPlatform/cloud-debug-java/releases/lates
 Examine the app.yaml contents, which provides a custom entry point that
 specifies the `-agentpath` java option to load the agent:
 
-https://github.com/GoogleCloudPlatform/snapshot-debugger/blob/bb6e9a271a61c31e66018c1a1ad844eec544bcf4/samples/java/appengine-java11/simple-server/app.yaml#L15-L17
+https://github.com/GoogleCloudPlatform/snapshot-debugger/blob/ef7db1b29937f1f6e140d69214aadf51bddb3770/samples/java/appengine-java11/simple-server/app.yaml#L15-L16
 
 Deploy the app with the following:
 

--- a/samples/java/appengine-java11/simple-server/README.md
+++ b/samples/java/appengine-java11/simple-server/README.md
@@ -1,8 +1,9 @@
 # Using the Java Agent on a Simple One File Server App in GAE Standard Java 11
 
-NOTE: This example was copied from
-[appengine-java11/custom-entrypoint](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/appengine-java11/custom-entrypoint)
-and modified for Snapshot Debugger Java agent use.
+> **Note**
+> This example was copied from
+> [appengine-java11/custom-entrypoint](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/appengine-java11/custom-entrypoint)
+> and modified for Snapshot Debugger Java agent use.
 
 
 ## Setup

--- a/samples/java/appengine-java11/simple-server/README.md
+++ b/samples/java/appengine-java11/simple-server/README.md
@@ -47,7 +47,7 @@ Make note of the following output entries, which should resemble the following:
 
 ```
 [...snip]
-target service:              [sample-java11-simple-server]
+target service:              [default]
 target version:              [20221122t161333]
 target url:                  [https://<your-project-id>.appspot.com]
 [...snip]
@@ -71,13 +71,12 @@ snapshot-dbg-cli list_debuggees
 ```
 
 The output will resemble the following. The first column will contain an entry
-`<service> - <version>`, which in this case is `sample-java11-simple-server -
-20221117t213436`.
+`<service> - <version>`, which in this case is `default - 20221117t213436`.
 
 ```
-Name                                           ID          Description
----------------------------------------------  ----------  -------------------------------------------------------------------------
-sample-java11-simple-server - 20221122t161333  d-ad4829f7  my-project-sample-java11-simple-server-20221122t161333-448054658875855015
+Name                       ID          Description
+-------------------------- ----------  ------------------------------------------------
+default - 20221122t161333  d-ad4829f7  my-project-id-20221122t161333-448054658875855015
 ```
 
 The debuggee ID in this case is  `d-ad4829f7`. Using this ID you may now run

--- a/samples/java/appengine-java11/simple-server/app.yaml
+++ b/samples/java/appengine-java11/simple-server/app.yaml
@@ -13,5 +13,4 @@
 # limitations under the License.
 
 runtime: java11
-service: sample-java11-simple-server
 entrypoint: java -agentpath:/workspace/cdbg/cdbg_java_agent.so=--use-firebase=true Main


### PR DESCRIPTION
This will help avoid issues with running through the examples, as if
this is the first deploy of an app engine app on the project it will
fail, since the first deploy must be the `default` service.