### PR TITLE
feat: list_debuggees supports active debuggees

### DIFF
--- a/snapshot_dbg_cli/COMMAND_REFERENCE.md
+++ b/snapshot_dbg_cli/COMMAND_REFERENCE.md
@@ -32,16 +32,18 @@ snapshot-cdbg-cli list_debuggees
 
 
 Usage: `__main__.py list_debuggees [-h] [--database-url DATABASE_URL] [--format
-FORMAT] [--debug]`
+FORMAT] [--debug] [--include-inactive]`
 
 Used to display a list of the debug targets (debuggees) registered with the
-Snapshot Debugger.
+Snapshot Debugger. By default all active debuggees are returned. To also obtain
+inactive debuggees specify the --include-inactive option.
 
 ### Optional arguments
 
 | Argument                      | Description |
 |-------------------------------|-------------|
 | `-h`, `--help`                | Show this help message and exit. |
+| `--include-inactive`          | Include inactive debuggees. |
 | `--database-url DATABASE_URL` | Specify the database URL for the CLI to use. This should only be used as an override to make the CLI talk to a specific instance and isn't expected to be needed. It is only required if the `--database-id` argument was used with the init command.  This value may be specified either via this command line argument or via the `SNAPSHOT_DEBUGGER_DATABASE_URL` environment variable.  When both are specified, the value from the command line takes precedence. |
 | `--format FORMAT`             | Set the format for printing command output resources. The default is a command-specific human-friendly output format. The supported formats are: `default`, `json` (raw) and `pretty-json` (formatted `json`). |
 | `--debug`                     | Enable CLI debug messages. |

--- a/snapshot_dbg_cli/COMMAND_REFERENCE.md
+++ b/snapshot_dbg_cli/COMMAND_REFERENCE.md
@@ -36,7 +36,9 @@ FORMAT] [--debug] [--include-inactive]`
 
 Used to display a list of the debug targets (debuggees) registered with the
 Snapshot Debugger. By default all active debuggees are returned. To also obtain
-inactive debuggees specify the --include-inactive option.
+inactive debuggees specify the --include-inactive option.  considered to be
+active if it was last running in the past 5-6 hours.  A debuggee is considered
+to be active if it currently running or last ran in the past 5-6 hours.
 
 ### Optional arguments
 

--- a/snapshot_dbg_cli/breakpoint_utils.py
+++ b/snapshot_dbg_cli/breakpoint_utils.py
@@ -17,9 +17,9 @@ These utilities are useful in multiple snapshot and logpoint commands.
 """
 
 import re
+import snapshot_dbg_cli.time_utils
 
 from snapshot_dbg_cli.status_message import StatusMessage
-from snapshot_dbg_cli.time_utils import convert_unix_msec_to_rfc3339
 
 # Regex that can be used to validate a user inputted location which should be in
 # the format file:line.
@@ -67,14 +67,11 @@ def transform_location_to_file_line(location):
 
 
 def set_converted_timestamps(bp):
-  conversions = [['createTime', 'createTimeUnixMsec'],
-                 ['finalTime', 'finalTimeUnixMsec']]
+  field_mappings = [('createTime', 'createTimeUnixMsec'),
+                    ('finalTime', 'finalTimeUnixMsec')]
 
-  for c in conversions:
-    if c[0] not in bp and c[1] in bp:
-      bp[c[0]] = convert_unix_msec_to_rfc3339(bp[c[1]])
-
-  return bp
+  return snapshot_dbg_cli.time_utils.set_converted_timestamps(
+      bp, field_mappings)
 
 
 # Returns None if there's an issue

--- a/snapshot_dbg_cli/breakpoint_utils.py
+++ b/snapshot_dbg_cli/breakpoint_utils.py
@@ -16,10 +16,10 @@
 These utilities are useful in multiple snapshot and logpoint commands.
 """
 
-import datetime
 import re
 
 from snapshot_dbg_cli.status_message import StatusMessage
+from snapshot_dbg_cli.time_utils import convert_unix_msec_to_rfc3339
 
 # Regex that can be used to validate a user inputted location which should be in
 # the format file:line.
@@ -64,37 +64,6 @@ def transform_location_to_file_line(location):
     return None
 
   return f"{location['path']}:{location['line']}"
-
-
-# Returns the id to use when creating a new breakpoint.
-# To note, we use the format 'b_<unix epoc seconds>'
-#
-# To note, this ensures the ID cannot be interpreted as an integer. This is
-# specifically done for the following reason:
-
-
-def convert_unix_msec_to_rfc3339(unix_msec):
-  """Converts a Unix timestamp represented in milliseconds since the epoch to an
-
-  RFC3339 string representation.
-
-  Args:
-    unix_msec: The Unix timestamp, represented in milliseconds since the epoch.
-
-  Returns:
-    An RFC3339 encoded timestamp string in format: "%Y-%m-%dT%H:%M:%S.%fZ".
-  """
-  try:
-    seconds = unix_msec / 1000
-    msec = unix_msec % 1000
-    timestamp = seconds
-    dt = datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
-    return dt.strftime(f'%Y-%m-%dT%H:%M:%S.{msec:03}000') + 'Z'
-  except (OverflowError, OSError, TypeError, ValueError):
-    # By using 0, we'll still get the expected formatted string, and the value
-    # will be '1970-01-01...', which visually will be recognizable as beginning
-    # of epoch and that the value was not known.
-    return convert_unix_msec_to_rfc3339(0)
 
 
 def set_converted_timestamps(bp):

--- a/snapshot_dbg_cli/debuggee_utils.py
+++ b/snapshot_dbg_cli/debuggee_utils.py
@@ -45,7 +45,7 @@ def normalize_debuggee(debuggee, current_time_unix_msec):
   This method ensures all required and expected fields are set. If any required
   field is not set, and cannot be filled in, None will be returned.
 
-  If a breakpoint is returned, the following fields are guaranteed to
+  If a debuggee is returned, the following fields are guaranteed to
   be populated:
 
     id
@@ -66,18 +66,8 @@ def normalize_debuggee(debuggee, current_time_unix_msec):
     registrationTime
     registrationTimeUnixMsec
 
-  If the 'action' field is 'CAPTURE', the breakpoint represents a snapshot, and
-  if it's 'LOG', the breakpoint represents a logpoint.
-
-  Additionally, if the breakpoint represents a logpoint (action is 'LOG'), the
-  following fields will be present:
-
-    logMessageFormat        - Form of 'a: $0, b: $1', used by the agents
-    logMessageFormatString  - Form of 'a: {a}, b: {b}', friendly user version
-    logLevel
-
   Returns:
-    The normalized breakpoint on success, None on failure.
+    The normalized debuggee on success, None on failure.
   """
   if not isinstance(debuggee, dict):
     return None

--- a/snapshot_dbg_cli/debuggee_utils.py
+++ b/snapshot_dbg_cli/debuggee_utils.py
@@ -14,7 +14,7 @@
 """This module provides a variety of utilities related to debuggees processing.
 """
 
-from snapshot_dbg_cli.time_utils import convert_unix_msec_to_rfc3339
+import snapshot_dbg_cli.time_utils
 
 MSEC_PER_HOUR = 60 * 60 * 1000
 DEBUGGEE_ACTIVE_THRESHOLD_MSEC = 6 * MSEC_PER_HOUR
@@ -29,14 +29,11 @@ def get_display_name(labels):
 
 
 def set_converted_timestamps(debuggee):
-  conversions = [['registrationTime', 'registrationTimeUnixMsec'],
-                 ['lastUpdateTime', 'lastUpdateTimeUnixMsec']]
+  field_mappings = [('registrationTime', 'registrationTimeUnixMsec'),
+                    ('lastUpdateTime', 'lastUpdateTimeUnixMsec')]
 
-  for c in conversions:
-    if c[0] not in debuggee and c[1] in debuggee:
-      debuggee[c[0]] = convert_unix_msec_to_rfc3339(debuggee[c[1]])
-
-  return debuggee
+  return snapshot_dbg_cli.time_utils.set_converted_timestamps(
+      debuggee, field_mappings)
 
 
 def normalize_debuggee(debuggee, current_time_unix_msec):

--- a/snapshot_dbg_cli/debuggee_utils.py
+++ b/snapshot_dbg_cli/debuggee_utils.py
@@ -1,0 +1,118 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module provides a variety of utilities related to debuggees processing.
+"""
+
+from snapshot_dbg_cli.time_utils import convert_unix_msec_to_rfc3339
+
+MSEC_PER_HOUR = 60 * 60 * 1000
+DEBUGGEE_ACTIVE_THRESHOLD_MSEC = 6 * MSEC_PER_HOUR
+DEBUGGEE_STALE_THRESHOLD_MSEC = 7 * 24 * MSEC_PER_HOUR
+
+
+def get_display_name(labels):
+  module = labels.get('module', 'default')
+  version = labels.get('version', '')
+
+  return f'{module} - {version}'
+
+
+def set_converted_timestamps(debuggee):
+  conversions = [['registrationTime', 'registrationTimeUnixMsec'],
+                 ['lastUpdateTime', 'lastUpdateTimeUnixMsec']]
+
+  for c in conversions:
+    if c[0] not in debuggee and c[1] in debuggee:
+      debuggee[c[0]] = convert_unix_msec_to_rfc3339(debuggee[c[1]])
+
+  return debuggee
+
+
+def normalize_debuggee(debuggee, current_time_unix_msec):
+  """Validates and normalizes a debuggee.
+
+  This method ensures all required and expected fields are set. If any required
+  field is not set, and cannot be filled in, None will be returned.
+
+  If a breakpoint is returned, the following fields are guaranteed to
+  be populated:
+
+    id
+    displayName
+    description
+    activeDebuggeeEnabled - Indicates the agent this debuggee represents
+                            supports the 'active debuggee' feature, and so the
+                            isActive and isStale fields are valid and accurate
+                            to rely on.  Early versions of the agents did not
+                            populate the lastUpdateTimeUnixMsec field.
+    isActive      - Indicates it has been recently active ~6hours. By default
+                    this will be false if activeDebuggeeEnabled is false.
+    isStale       - Indicates it has not been active for a long period
+                    (~7days).  By default this will be false if
+                    activeDebuggeeEnabled is false.
+    lastUpdateTime
+    lastUpdateTimeUnixMsec
+    registrationTime
+    registrationTimeUnixMsec
+
+  If the 'action' field is 'CAPTURE', the breakpoint represents a snapshot, and
+  if it's 'LOG', the breakpoint represents a logpoint.
+
+  Additionally, if the breakpoint represents a logpoint (action is 'LOG'), the
+  following fields will be present:
+
+    logMessageFormat        - Form of 'a: $0, b: $1', used by the agents
+    logMessageFormatString  - Form of 'a: {a}, b: {b}', friendly user version
+    logLevel
+
+  Returns:
+    The normalized breakpoint on success, None on failure.
+  """
+  if not isinstance(debuggee, dict):
+    return None
+
+  required_fields = ['id']
+  for f in required_fields:
+    if f not in debuggee:
+      return None
+
+  if 'description' not in debuggee:
+    debuggee['description'] = ''
+
+  debuggee['displayName'] = get_display_name(debuggee.get('labels', {}))
+
+  debuggee['activeDebuggeeEnabled'] = 'lastUpdateTimeUnixMsec' in debuggee
+
+  if 'registrationTimeUnixMsec' not in debuggee:
+    # Debuggees created by older agents won't have this field present,
+    # initialize it to 0 so it's set to something, but it's clear the
+    # time was not actually known.
+    debuggee['registrationTimeUnixMsec'] = 0
+
+  if 'lastUpdateTimeUnixMsec' not in debuggee:
+    # Debuggees created by older agents won't have this field present,
+    # initialize it to 0 so it's set to something, but it's clear the
+    # time was not actually known.
+    debuggee['lastUpdateTimeUnixMsec'] = 0
+
+  set_converted_timestamps(debuggee)
+
+  debuggee['isActive'] = (
+      current_time_unix_msec -
+      debuggee['lastUpdateTimeUnixMsec']) <= DEBUGGEE_ACTIVE_THRESHOLD_MSEC
+  debuggee['isStale'] = (
+      current_time_unix_msec -
+      debuggee['lastUpdateTimeUnixMsec']) > DEBUGGEE_STALE_THRESHOLD_MSEC
+
+  return debuggee

--- a/snapshot_dbg_cli/list_debuggees_command.py
+++ b/snapshot_dbg_cli/list_debuggees_command.py
@@ -21,11 +21,11 @@ import time
 
 DESCRIPTION = """
 Used to display a list of the debug targets (debuggees) registered with the
-Snapshot Debugger. By default all active debuggees are returned. To obtained
+Snapshot Debugger. By default all active debuggees are returned. To also obtain
 inactive debuggees specify the --include-inactive option.
 """
 
-INCLUDE_INACTIVE_HELP = 'Include all debuggees, both active and inactive.'
+INCLUDE_INACTIVE_HELP = 'Include inactive debuggees.'
 
 
 class ListDebuggeesCommand:
@@ -64,10 +64,9 @@ class ListDebuggeesCommand:
       if any(d['activeDebuggeeEnabled'] for d in debuggees):
         debuggees = list(filter(lambda d: d['isActive'], debuggees))
 
-    # We add the second sort parameter on displayName as in the case of older
-    # agents that don't support the 'active debuggee' feature, they will all
-    # have the same lastUpdateTimeUnixMsec of 0, so their will still get some
-    # sorting.
+    # We add the second sort parameter on displayName for older agents that
+    # don't support the 'active debuggee' feature. They will all have the same
+    # lastUpdateTimeUnixMsec of 0, so they will still get some useful sorting.
     debuggees = sorted(
         debuggees,
         key=lambda d: (d['lastUpdateTimeUnixMsec'], d['displayName']),

--- a/snapshot_dbg_cli/list_debuggees_command.py
+++ b/snapshot_dbg_cli/list_debuggees_command.py
@@ -22,7 +22,9 @@ import time
 DESCRIPTION = """
 Used to display a list of the debug targets (debuggees) registered with the
 Snapshot Debugger. By default all active debuggees are returned. To also obtain
-inactive debuggees specify the --include-inactive option.
+inactive debuggees specify the --include-inactive option.  A debuggee is
+considered to be active if it currently running or last ran in the past 5-6
+hours.
 """
 
 INCLUDE_INACTIVE_HELP = 'Include inactive debuggees.'

--- a/snapshot_dbg_cli/snapshot_debugger_rtdb_service.py
+++ b/snapshot_dbg_cli/snapshot_debugger_rtdb_service.py
@@ -15,6 +15,7 @@
 """
 
 from snapshot_dbg_cli.breakpoint_utils import normalize_breakpoint
+from snapshot_dbg_cli.debuggee_utils import normalize_debuggee
 from snapshot_dbg_cli.exceptions import SilentlyExitError
 
 import time
@@ -50,8 +51,18 @@ class SnapshotDebuggerRtdbService:
   def set_schema_version(self, version):
     return self.rest_service.set(self.schema.get_path_schema_version(), version)
 
-  def get_debuggees(self):
-    return self.rest_service.get(self.schema.get_path_debuggees())
+  def get_debuggees(self, current_time_unix_msec):
+    debuggees = self.rest_service.get(self.schema.get_path_debuggees()) or {}
+
+    # The result will be a dictionary, convert it to an array, while also
+    # filtering out any invalid entries, normalize_debuggee returns None for
+    # invalid debuggee.
+    debuggees = [
+        dbgee for dbgee_id, dbgee in debuggees.items()
+        if normalize_debuggee(dbgee, current_time_unix_msec)
+    ]
+
+    return debuggees
 
   def validate_debuggee_id(self, debuggee_id):
     """Validates the debuggee ID exists.
@@ -75,6 +86,11 @@ class SnapshotDebuggerRtdbService:
           DEBUGGEE_NOT_FOUND_ERROR_MESSAGE.format(debuggee_id=debuggee_id))
       raise SilentlyExitError
 
+  # Returns the id to use when creating a new breakpoint.
+  # To note, we use the format 'b_<unix epoc seconds>' this ensures the ID
+  # cannot be interpreted as an integer. This is specifically done for the
+  # following reason:
+  #
   # Per
   # https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
   # "If all of the keys are integers, and more than half of the keys are between

--- a/snapshot_dbg_cli/snapshot_debugger_rtdb_service.py
+++ b/snapshot_dbg_cli/snapshot_debugger_rtdb_service.py
@@ -55,8 +55,8 @@ class SnapshotDebuggerRtdbService:
     debuggees = self.rest_service.get(self.schema.get_path_debuggees()) or {}
 
     # The result will be a dictionary, convert it to an array, while also
-    # filtering out any invalid entries, normalize_debuggee returns None for
-    # invalid debuggee.
+    # filtering out any invalid entries. normalize_debuggee returns None for
+    # invalid debuggees.
     debuggees = [
         dbgee for dbgee_id, dbgee in debuggees.items()
         if normalize_debuggee(dbgee, current_time_unix_msec)

--- a/snapshot_dbg_cli/time_utils.py
+++ b/snapshot_dbg_cli/time_utils.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module provides utilities related to timestamps.
+"""
+
+import datetime
+
+
+def convert_unix_msec_to_rfc3339(unix_msec):
+  """Converts a Unix timestamp represented in milliseconds since the epoch to an
+
+  RFC3339 string representation.
+
+  Args:
+    unix_msec: The Unix timestamp, represented in milliseconds since the epoch.
+
+  Returns:
+    An RFC3339 encoded timestamp string in format: "%Y-%m-%dT%H:%M:%S.%fZ".
+  """
+  try:
+    seconds = unix_msec / 1000
+    msec = unix_msec % 1000
+    timestamp = seconds
+    dt = datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+    return dt.strftime(f'%Y-%m-%dT%H:%M:%S.{msec:03}000') + 'Z'
+  except (OverflowError, OSError, TypeError, ValueError):
+    # By using 0, we'll still get the expected formatted string, and the value
+    # will be '1970-01-01...', which visually will be recognizable as beginning
+    # of epoch and that the value was not known.
+    return convert_unix_msec_to_rfc3339(0)

--- a/snapshot_dbg_cli/time_utils.py
+++ b/snapshot_dbg_cli/time_utils.py
@@ -39,3 +39,48 @@ def convert_unix_msec_to_rfc3339(unix_msec):
     # will be '1970-01-01...', which visually will be recognizable as beginning
     # of epoch and that the value was not known.
     return convert_unix_msec_to_rfc3339(0)
+
+
+def set_converted_timestamps(data, field_mappings):
+  """Converts raw unix timestamp fields to human readable versions.
+
+  If the destination field already exists it won't be overwritten.
+
+  Example:
+  data = {
+    fooTimeUnixMsec: 1649962215000
+    barTimeUnixMsec: 1649962216000
+  }
+
+  field_mappings = [
+    ('fooTime', 'fooTimeUnixMsec'),
+    ('barTIme, 'barTimeUnixMsec')
+  ]
+
+  set_converted_timestamps(data, field_mappings)
+  data = {
+    fooTimeUnixMsec: 1649962215000
+    fooTime: '2022-04-14T18:50:15.000000Z'
+    barTimeUnixMsec = 1649962216000
+    barTime: '2022-04-14T18:50:16.000000Z'
+  }
+
+
+  Args:
+    data: The container dict, expected to represent either a breakpoint a
+      debuggee.
+    field_mappings: [(str, str)] List of field mappings. For each entry the
+      first member is the destination field to be set with a human readable
+      timestamp. The second member is the source field and should map to a unix
+      timestamp in data.
+
+  Returns:
+    The data dict that was passed in.
+  """
+
+  for m in field_mappings:
+    if m[0] not in data and m[1] in data:
+      data[m[0]] = convert_unix_msec_to_rfc3339(
+          data[m[1]]) if data[m[1]] != 0 else 'not set'
+
+  return data

--- a/snapshot_dbg_cli_tests/test_breakpoint_utils.py
+++ b/snapshot_dbg_cli_tests/test_breakpoint_utils.py
@@ -17,7 +17,6 @@
 import copy
 import unittest
 
-from snapshot_dbg_cli.breakpoint_utils import convert_unix_msec_to_rfc3339
 from snapshot_dbg_cli.breakpoint_utils import get_logpoint_short_status
 from snapshot_dbg_cli.breakpoint_utils import merge_log_expressions
 from snapshot_dbg_cli.breakpoint_utils import normalize_breakpoint
@@ -100,27 +99,6 @@ class SnapshotDebuggerBreakpointUtilsTests(unittest.TestCase):
             'path': 'foo.py',
             'line': 10
         }))
-
-  def test_convert_unix_msec_to_rfc3339(self):
-    self.assertEqual('2022-04-14T18:50:15.000000Z',
-                     convert_unix_msec_to_rfc3339(1649962215000))
-    self.assertEqual('2022-04-14T18:50:15.001000Z',
-                     convert_unix_msec_to_rfc3339(1649962215001))
-    self.assertEqual('2022-04-14T18:50:15.010000Z',
-                     convert_unix_msec_to_rfc3339(1649962215010))
-    self.assertEqual('2022-04-14T18:50:15.100000Z',
-                     convert_unix_msec_to_rfc3339(1649962215100))
-    self.assertEqual('2022-04-14T18:50:15.426000Z',
-                     convert_unix_msec_to_rfc3339(1649962215426))
-
-    # For any invalid input, the function will default to using a value of 0,
-    # which represents the epoch (1970-01-01). This way the function can still
-    # return a properly formatting string, and the value is recognizable as
-    # indicating there was an issue and the actual time is not known.
-    self.assertEqual('1970-01-01T00:00:00.000000Z',
-                     convert_unix_msec_to_rfc3339(999999999999999))
-    self.assertEqual('1970-01-01T00:00:00.000000Z',
-                     convert_unix_msec_to_rfc3339('asdf'))
 
   def test_set_converted_timestamps(self):
     """Verifies the set_converted_timestamps() works as expected.

--- a/snapshot_dbg_cli_tests/test_debuggee_utils.py
+++ b/snapshot_dbg_cli_tests/test_debuggee_utils.py
@@ -34,7 +34,7 @@ class SnapshotDebuggerDebuggeeUtilsTests(unittest.TestCase):
     changes are done.
     """
 
-    # Note, these tests don't need fully flesched out breakpoints, the function
+    # Note, these tests don't need fully fleshed out debuggees, the function
     # under test only cares about time fields in a dict, so these minimal dicts
     # suffice.
     testcases = [

--- a/snapshot_dbg_cli_tests/test_debuggee_utils.py
+++ b/snapshot_dbg_cli_tests/test_debuggee_utils.py
@@ -1,0 +1,308 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Unit test file for the debuggee_utils module.
+"""
+
+import copy
+import unittest
+
+from snapshot_dbg_cli.debuggee_utils import get_display_name
+from snapshot_dbg_cli.debuggee_utils import normalize_debuggee
+from snapshot_dbg_cli.debuggee_utils import set_converted_timestamps
+
+
+class SnapshotDebuggerDebuggeeUtilsTests(unittest.TestCase):
+  """ Contains the unit tests for the breakpoint_utils module.
+  """
+
+  def test_set_converted_timestamps(self):
+    """Verifies the set_converted_timestamps() works as expected.
+
+    If the human readable time is not in the breakpoint, but the unix msec
+    version is, the human readable version should be populated, otherwise no
+    changes are done.
+    """
+
+    # Note, these tests don't need fully flesched out breakpoints, the function
+    # under test only cares about time fields in a dict, so these minimal dicts
+    # suffice.
+    testcases = [
+        ('No time fields', {}, {}),
+        (
+            'registrationTime gets populated',
+            {
+                'registrationTimeUnixMsec': 1649962215000
+            },
+            {
+                'registrationTimeUnixMsec': 1649962215000,
+                'registrationTime': '2022-04-14T18:50:15.000000Z'
+            },
+        ),
+        (
+            'registrationTime not overrwritten',
+            {
+                'registrationTimeUnixMsec': 1649962215000,
+                'registrationTime': 'exists not overwritten'
+            },
+            {
+                'registrationTimeUnixMsec': 1649962215000,
+                'registrationTime': 'exists not overwritten'
+            },
+        ),
+        (
+            'lastUpdateTime gets populated',
+            {
+                'lastUpdateTimeUnixMsec': 1649962215000
+            },
+            {
+                'lastUpdateTimeUnixMsec': 1649962215000,
+                'lastUpdateTime': '2022-04-14T18:50:15.000000Z'
+            },
+        ),
+        (
+            'lastUpdateTime not overrwritten',
+            {
+                'lastUpdateTimeUnixMsec': 1649962215000,
+                'lastUpdateTime': 'exists not overwritten'
+            },
+            {
+                'lastUpdateTimeUnixMsec': 1649962215000,
+                'lastUpdateTime': 'exists not overwritten'
+            },
+        ),
+        (
+            'Both registrationTime and lastUpdateTime populated',
+            {
+                'registrationTimeUnixMsec': 1649962215000,
+                'lastUpdateTimeUnixMsec': 1649962215001
+            },
+            {
+                'registrationTimeUnixMsec': 1649962215000,
+                'registrationTime': '2022-04-14T18:50:15.000000Z',
+                'lastUpdateTimeUnixMsec': 1649962215001,
+                'lastUpdateTime': '2022-04-14T18:50:15.001000Z'
+            },
+        ),
+    ]
+
+    for test_name, debuggee, expected_debuggee in testcases:
+      with self.subTest(test_name):
+        self.assertEqual(expected_debuggee, set_converted_timestamps(debuggee))
+
+  def test_normalize_debuggee_returns_none_when_breakpoint_not_a_dict(self):
+    current_time = 1649962215000888
+    self.assertIsNone(normalize_debuggee(None, current_time))
+    self.assertIsNone(normalize_debuggee(1, current_time))
+    self.assertIsNone(normalize_debuggee([1], current_time))
+    self.assertIsNone(normalize_debuggee('foo', current_time))
+    self.assertIsNone(normalize_debuggee(['foo'], current_time))
+
+  def test_normalize_debuggee_returns_none_when_missing_required_fields(self):
+    """Verify normalize_debuggee() returns None when required fields missing.
+
+    The function will generally fill in some missing fields with sane defaults,
+    however certain critical required fields cannot be filled in this way. These
+    are fields a valid debuggee would be expected to have populated.
+    """
+    current_time = 1649962215000888
+    debuggee = {
+        'id': 'd-ab1234cd',
+        'labels': {
+            'module': 'foo',
+            'version': 'v1'
+        },
+        'description': 'foo msg'
+    }
+
+    # Sanity check the debuggee we're using as a base is valid.
+    self.assertIsNotNone(normalize_debuggee(debuggee, current_time))
+
+    missing_debuggee_id = copy.deepcopy(debuggee)
+    del missing_debuggee_id['id']
+
+    self.assertIsNone(normalize_debuggee(missing_debuggee_id, current_time))
+
+  def test_normalize_debuggee_populates_display_name_when_labels_missing(self):
+    current_time = 1649962215000888
+    debuggee = {'id': 'd-ab1234cd', 'description': 'foo msg'}
+
+    self.assertIsNotNone(normalize_debuggee(debuggee, current_time))
+    self.assertIn('displayName', debuggee)
+    self.assertEqual(get_display_name({}), debuggee['displayName'])
+
+  def test_normalize_debuggee_active_debuggee_enabled_field(self):
+    current_time = 1649962215000888
+    debuggee_not_enabled = {'id': 'd-ab1234cd', 'description': 'foo msg'}
+
+    debuggee_enabled = {
+        'id': 'd-ab1234cd',
+        'description': 'foo msg',
+        'registrationTimeUnixMsec': 1649962215426,
+        'lastUpdateTimeUnixMsec': 1670000000001,
+    }
+
+    self.assertIsNotNone(normalize_debuggee(debuggee_not_enabled, current_time))
+    self.assertIsNotNone(normalize_debuggee(debuggee_enabled, current_time))
+    self.assertIn('activeDebuggeeEnabled', debuggee_not_enabled)
+    self.assertIn('activeDebuggeeEnabled', debuggee_enabled)
+    self.assertFalse(debuggee_not_enabled['activeDebuggeeEnabled'])
+    self.assertTrue(debuggee_enabled['activeDebuggeeEnabled'])
+
+  def test_normalize_debuggee_is_active_field_defaults_false(self):
+    current_time = 1670000000000
+
+    # When the lastUpdateTimeUnixMsec is missing, 'isActive' should be false
+    debuggee = {'id': 'd-ab1234cd', 'description': 'foo msg'}
+
+    self.assertIsNotNone(normalize_debuggee(debuggee, current_time))
+    self.assertIn('isActive', debuggee)
+    self.assertFalse(debuggee['isActive'])
+
+  def test_normalize_debuggee_is_active_field(self):
+    current_time = 1670000000000
+    msec_per_hour = 60 * 60 * 1000
+
+    # The active threshold is expected to be 6 hours
+    active_threshold = 6 * msec_per_hour
+
+    base_debuggee = {
+        'id': 'd-ab1234cd',
+        'description': 'foo msg',
+        'registrationTimeUnixMsec': 1649962215426,
+        'lastUpdateTimeUnixMsec': 0
+    }
+
+    testcases = [
+        ('Not active by 100 msec', current_time - active_threshold - 100,
+         False),
+        ('Not active by 1 msec', current_time - active_threshold - 1, False),
+        ('Active at threshold', current_time - active_threshold, True),
+        ('Active under threshold by 1', current_time - active_threshold + 1,
+         True),
+        ('Active under threshold by 100', current_time - active_threshold + 100,
+         True),
+
+        # Just in case local clock is slightly ahead of the server time, ensure
+        # it works as expected.
+        ('Active update time newer than current', current_time + 100, True),
+    ]
+
+    for test_name, last_update_time_msec, expected_is_valid in testcases:
+      with self.subTest(test_name):
+        debuggee = copy.deepcopy(base_debuggee)
+        debuggee['lastUpdateTimeUnixMsec'] = last_update_time_msec
+
+        self.assertIsNotNone(normalize_debuggee(debuggee, current_time))
+        self.assertIn('isActive', debuggee)
+        self.assertEqual(expected_is_valid, debuggee['isActive'])
+
+  def test_normalize_debuggee_is_stale_field_defaults_true(self):
+    current_time = 1670000000000
+
+    # When the lastUpdateTimeUnixMsec is missing, 'isActive' should be false
+    debuggee = {'id': 'd-ab1234cd', 'description': 'foo msg'}
+
+    self.assertIsNotNone(normalize_debuggee(debuggee, current_time))
+    self.assertIn('isStale', debuggee)
+    self.assertTrue(debuggee['isStale'])
+
+  def test_normalize_debuggee_is_stale_field(self):
+    current_time = 1670000000000
+    msec_per_hour = 60 * 60 * 1000
+
+    # The stale threshold is expected to be 7 days
+    active_threshold = 7 * 24 * msec_per_hour
+
+    base_debuggee = {
+        'id': 'd-ab1234cd',
+        'description': 'foo msg',
+        'registrationTimeUnixMsec': 1649962215426,
+        'lastUpdateTimeUnixMsec': 0
+    }
+
+    testcases = [
+        ('Stale by 100 msec', current_time - active_threshold - 100, True),
+        ('Stale by 1 msec', current_time - active_threshold - 1, True),
+        ('Not stale at threshold', current_time - active_threshold, False),
+        ('Not stale under threshold by 1', current_time - active_threshold + 1,
+         False),
+        ('Not stale under threshold by 100',
+         current_time - active_threshold + 100, False),
+
+        # Just in case local clock is slightly ahead of the server time, ensure
+        # it works as expected.
+        ('Not stale update time newer than current', current_time + 100, False),
+    ]
+
+    for test_name, last_update_time_msec, expected_is_valid in testcases:
+      with self.subTest(test_name):
+        debuggee = copy.deepcopy(base_debuggee)
+        debuggee['lastUpdateTimeUnixMsec'] = last_update_time_msec
+
+        self.assertIsNotNone(normalize_debuggee(debuggee, current_time))
+        self.assertIn('isStale', debuggee)
+        self.assertEqual(expected_is_valid, debuggee['isStale'])
+
+  def test_normalize_debuggee_populates_missing_fields_as_expected(self):
+    # To note, we're using a completed snapshot here since finalTime will only
+    # be polpulated if the breakpoint is final.
+
+    current_time = 1649962215000888
+    base_debuggee = {
+        'id': 'd-ab1234cd',
+        'labels': {
+            'module': 'foo',
+            'version': 'v1'
+        },
+        'description': 'foo msg',
+        'registrationTimeUnixMsec': 1649962215426,
+        'lastUpdateTimeUnixMsec': 1649962230637,
+        'registrationTime': '2022-04-14T18:50:15.426000Z',
+        'lastUpdateTime': '2022-04-14T18:50:30.637000Z',
+        'displayName': 'foo - v1',
+    }
+
+    testcases = [
+        # (missing field, expected fill in value)
+        ('description', ''),
+        ('registrationTimeUnixMsec', 0),
+        ('lastUpdateTimeUnixMsec', 0),
+        ('registrationTime', '2022-04-14T18:50:15.426000Z'),
+        ('lastUpdateTime', '2022-04-14T18:50:30.637000Z'),
+        ('displayName', 'foo - v1'),
+    ]
+
+    for missing_field, expected_field_value in testcases:
+      test_name = missing_field
+      with self.subTest(test_name):
+        debuggee = copy.deepcopy(base_debuggee)
+        del debuggee[missing_field]
+        self.assertNotIn(missing_field, debuggee)
+
+        obtained_debuggee = normalize_debuggee(debuggee, current_time)
+
+        # It's expected the same instance is returned.
+        self.assertIs(obtained_debuggee, debuggee)
+        self.assertIn(missing_field, obtained_debuggee)
+        self.assertEqual(expected_field_value, obtained_debuggee[missing_field])
+
+  def test_get_display_name(self):
+    self.assertEqual(get_display_name({}), 'default - ')
+    self.assertEqual(get_display_name({'module': 'foo'}), 'foo - ')
+    self.assertEqual(get_display_name({'version': 'v1'}), 'default - v1')
+    self.assertEqual(
+        get_display_name({
+            'module': 'foo',
+            'version': 'v1'
+        }), 'foo - v1')

--- a/snapshot_dbg_cli_tests/test_snapshot_debugger_rtdb_service.py
+++ b/snapshot_dbg_cli_tests/test_snapshot_debugger_rtdb_service.py
@@ -28,23 +28,27 @@ from unittest.mock import call
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-DEBUGGEE_1 = ({
+DEBUGGEE_1 = {
     'id': '123',
     'labels': {
         'module': 'app123',
         'version': 'v1'
     },
     'description': 'desc 1'
-}, ['app123 - v1', '123', 'desc 1'])
+}
 
-DEBUGGEE_2 = ({
+DEBUGGEE_2 = {
     'id': '456',
     'labels': {
         'module': 'app456',
         'version': 'v2'
     },
     'description': 'desc 2'
-}, ['app456 - v2', '456', 'desc 2'])
+}
+
+
+def debuggees_to_dict(debuggees):
+  return dict((d['id'], d) for d in debuggees)
 
 SNAPSHOT_ACTIVE =  {
   'action': 'CAPTURE',
@@ -126,10 +130,12 @@ class SnapshotDebuggerRtdbServiceTests(unittest.TestCase):
     self.assertEqual('1', version)
 
   def test_get_debuggees_works_as_expected(self):
-    self.firebase_rtdb_service_mock.get = MagicMock(
-        return_value=[DEBUGGEE_1, DEBUGGEE_2])
+    current_time = 1649962215000888
 
-    debuggees = self.debugger_rtdb_service.get_debuggees()
+    self.firebase_rtdb_service_mock.get = MagicMock(
+        return_value=debuggees_to_dict([DEBUGGEE_1, DEBUGGEE_2]))
+
+    debuggees = self.debugger_rtdb_service.get_debuggees(current_time)
 
     self.assertEqual([DEBUGGEE_1, DEBUGGEE_2], debuggees)
     self.firebase_rtdb_service_mock.get.assert_called_once_with(

--- a/snapshot_dbg_cli_tests/test_time_utils.py
+++ b/snapshot_dbg_cli_tests/test_time_utils.py
@@ -1,0 +1,45 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Unit test file for the debuggee_utils module.
+"""
+
+import unittest
+
+from snapshot_dbg_cli.time_utils import convert_unix_msec_to_rfc3339
+
+
+class ListDebuggeesCommandTests(unittest.TestCase):
+  """ Contains the unit tests for the time_utils module.
+  """
+
+  def test_convert_unix_msec_to_rfc3339(self):
+    self.assertEqual('2022-04-14T18:50:15.000000Z',
+                     convert_unix_msec_to_rfc3339(1649962215000))
+    self.assertEqual('2022-04-14T18:50:15.001000Z',
+                     convert_unix_msec_to_rfc3339(1649962215001))
+    self.assertEqual('2022-04-14T18:50:15.010000Z',
+                     convert_unix_msec_to_rfc3339(1649962215010))
+    self.assertEqual('2022-04-14T18:50:15.100000Z',
+                     convert_unix_msec_to_rfc3339(1649962215100))
+    self.assertEqual('2022-04-14T18:50:15.426000Z',
+                     convert_unix_msec_to_rfc3339(1649962215426))
+
+    # For any invalid input, the function will default to using a value of 0,
+    # which represents the epoch (1970-01-01). This way the function can still
+    # return a properly formatting string, and the value is recognizable as
+    # indicating there was an issue and the actual time is not known.
+    self.assertEqual('1970-01-01T00:00:00.000000Z',
+                     convert_unix_msec_to_rfc3339(999999999999999))
+    self.assertEqual('1970-01-01T00:00:00.000000Z',
+                     convert_unix_msec_to_rfc3339('asdf'))


### PR DESCRIPTION
In support of https://github.com/GoogleCloudPlatform/snapshot-debugger/issues/76 the `list_debuggees` command now:
- Shows only active debuggees by default
- Supports a `--include-inactive` flag
- Sorts the output with the most recently active debuggees being shown
  first.