### PR TITLE
docs: Add sample Node.js GCE app

### DIFF
--- a/samples/node-js/gce/app.js
+++ b/samples/node-js/gce/app.js
@@ -1,0 +1,37 @@
+// Copyright 2017 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+require('@google-cloud/debug-agent').start({
+  useFirebase: true,
+  allowExpressions: true,
+});
+
+const express = require('express');
+
+const app = express();
+
+app.get('/', (req, res) => {
+  res.status(200).send('Hello, world!').end();
+});
+
+// Start the server
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => {
+  console.log(`App listening on port ${PORT}`);
+  console.log('Press Ctrl+C to quit.');
+});
+
+module.exports = app;

--- a/samples/node-js/gce/package.json
+++ b/samples/node-js/gce/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "gce-hello-world",
+  "description": "Simple Hello World Node.js sample for Google Compute Engine.",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache-2.0",
+  "author": "Google Inc.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleCloudPlatform/nodejs-getting-started.git"
+  },
+  "engines": {
+    "node": ">=12"
+  },
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^4.16.3",
+    "@google-cloud/debug-agent": "^7.2.1"
+  }
+}


### PR DESCRIPTION
This sample app will show users how to set up the snapshot debugger node.js agent in GCE.

Follow-up CLs will be created for the startup script and the README that will include instructions.  The startup script will download the app from this repo, however, so this must be checked in first.