### PR TITLE
chore: release 0.3.0

### DIFF
--- a/snapshot_dbg_cli/cli_version.py
+++ b/snapshot_dbg_cli/cli_version.py
@@ -22,7 +22,7 @@ from snapshot_dbg_cli.exceptions import SilentlyExitError
 from snapshot_dbg_cli.http_service import HttpService
 from snapshot_dbg_cli.user_output import UserOutput
 
-VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_2_2'
+VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_3_0'
 
 VERSION_PATTERN = 'SNAPSHOT_DEBUGGER_CLI_VERSION_[0-9]+_[0-9]+_[0-9]+'
 

--- a/snapshot_dbg_cli_tests/test_init.py
+++ b/snapshot_dbg_cli_tests/test_init.py
@@ -24,4 +24,4 @@ class CliInitTests(unittest.TestCase):
 
   def test_version_is_expected_value(self):
     # Yes, this will need to be updated for each new version.
-    self.assertEqual('0.2.2', snapshot_dbg_cli.__version__)
+    self.assertEqual('0.3.0', snapshot_dbg_cli.__version__)


### PR DESCRIPTION
This is a minor version bump to account for active debuggee support.
* `list_debuggees` now supports the `--include-inactive` option and by default will only show active debuggees. In addition is has two new output columns, `Status` and `Last Active`.
* A new command `delete_debuggees` has been added, which by default it will only delete stale debuggees.
* An improvement for the `init` command is also included, which reduces the chances of it failing attempting to initialize the DB instance after creating it.