### PR TITLE
chore: Release 0.3.3

### DIFF
--- a/snapshot_dbg_cli/cli_version.py
+++ b/snapshot_dbg_cli/cli_version.py
@@ -22,7 +22,7 @@ from snapshot_dbg_cli.exceptions import SilentlyExitError
 from snapshot_dbg_cli.http_service import HttpService
 from snapshot_dbg_cli.user_output import UserOutput
 
-VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_3_2'
+VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_3_3'
 
 VERSION_PATTERN = 'SNAPSHOT_DEBUGGER_CLI_VERSION_[0-9]+_[0-9]+_[0-9]+'
 

--- a/snapshot_dbg_cli_tests/test_init.py
+++ b/snapshot_dbg_cli_tests/test_init.py
@@ -24,4 +24,4 @@ class CliInitTests(unittest.TestCase):
 
   def test_version_is_expected_value(self):
     # Yes, this will need to be updated for each new version.
-    self.assertEqual('0.3.2', snapshot_dbg_cli.__version__)
+    self.assertEqual('0.3.3', snapshot_dbg_cli.__version__)


### PR DESCRIPTION
- set_snapshot command now explicitly sets `action` field
- Main README updates
  - Note about Java 8 not being supported now removed (it is now supported).
  - Clarification added to Support Period