### PR TITLE
Don't rely on call_args.args in unit tests.

### DIFF
--- a/snapshot_dbg_cli_tests/test_delete_debuggees_command.py
+++ b/snapshot_dbg_cli_tests/test_delete_debuggees_command.py
@@ -179,7 +179,7 @@ class DeleteDebuggeesCommandTests(unittest.TestCase):
 
     self.rtdb_service_mock.delete_debuggees.assert_called_once()
     self.assertCountEqual(
-        [d1, d2, d3], self.rtdb_service_mock.delete_debuggees.call_args.args[0])
+        [d1, d2, d3], self.rtdb_service_mock.delete_debuggees.call_args[0][0])
 
   def test_by_default_only_stale_debuggees_deleted(self):
     testargs = []
@@ -204,7 +204,7 @@ class DeleteDebuggeesCommandTests(unittest.TestCase):
     self.rtdb_service_mock.get_debuggees.assert_called_once_with(ANY)
     self.assertCountEqual(
         [DEBUGGEE_INACTIVE, DEBUGGEE_STALE],
-        self.rtdb_service_mock.delete_debuggees.call_args.args[0])
+        self.rtdb_service_mock.delete_debuggees.call_args[0][0])
 
   def test_include_all_flag_deletes_inactive_stale_and_acitve_debuggees(self):
     testargs = ['--include-all']
@@ -217,7 +217,7 @@ class DeleteDebuggeesCommandTests(unittest.TestCase):
     self.rtdb_service_mock.get_debuggees.assert_called_once_with(ANY)
     self.assertCountEqual(
         [DEBUGGEE_ACTIVE, DEBUGGEE_INACTIVE, DEBUGGEE_STALE],
-        self.rtdb_service_mock.delete_debuggees.call_args.args[0])
+        self.rtdb_service_mock.delete_debuggees.call_args[0][0])
 
   def test_user_prompted_with_debuggee_summary_before_delete(self):
     expected_headers = ['Name', 'ID', 'Last Active', 'Status']
@@ -265,7 +265,7 @@ class DeleteDebuggeesCommandTests(unittest.TestCase):
         self.user_output_mock.tabular.assert_called_once_with(
             expected_headers, ANY)
         self.assertCountEqual(expected_rows,
-                              self.user_output_mock.tabular.call_args.args[1])
+                              self.user_output_mock.tabular.call_args[0][1])
 
         self.user_input_mock.prompt_user_to_continue.assert_called_once()
 

--- a/snapshot_dbg_cli_tests/test_list_debuggees_command.py
+++ b/snapshot_dbg_cli_tests/test_list_debuggees_command.py
@@ -268,7 +268,7 @@ class ListDebuggeesCommandTests(unittest.TestCase):
         self.user_output_mock.tabular.assert_called_once_with(
             expected_headers, ANY)
         self.assertCountEqual(expected_tabular_data,
-                              self.user_output_mock.tabular.call_args.args[1])
+                              self.user_output_mock.tabular.call_args[0][1])
 
   def test_output_format_json(self):
     testcases = [


### PR DESCRIPTION
The `args` property was added to `call_args` in Python 3.8
(https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.call_args)

We want to be able to run the unit tests earlier versions an so must avoid using it.