### PR TITLE
chore: Release 0.3.4

### DIFF
--- a/snapshot_dbg_cli/cli_version.py
+++ b/snapshot_dbg_cli/cli_version.py
@@ -22,7 +22,7 @@ from snapshot_dbg_cli.exceptions import SilentlyExitError
 from snapshot_dbg_cli.http_service import HttpService
 from snapshot_dbg_cli.user_output import UserOutput
 
-VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_3_3'
+VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_3_4'
 
 VERSION_PATTERN = 'SNAPSHOT_DEBUGGER_CLI_VERSION_[0-9]+_[0-9]+_[0-9]+'
 

--- a/snapshot_dbg_cli_tests/test_init.py
+++ b/snapshot_dbg_cli_tests/test_init.py
@@ -1,7 +1,3 @@
-chore: Release 0.3.4
-
-- Remove use of str.removeprefix, which fixes/allows the CLI to
-  run on Python < 3.9
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/snapshot_dbg_cli_tests/test_init.py
+++ b/snapshot_dbg_cli_tests/test_init.py
@@ -1,3 +1,7 @@
+chore: Release 0.3.4
+
+- Remove use of str.removeprefix, which fixes/allows the CLI to
+  run on Python < 3.9
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,4 +28,4 @@ class CliInitTests(unittest.TestCase):
 
   def test_version_is_expected_value(self):
     # Yes, this will need to be updated for each new version.
-    self.assertEqual('0.3.3', snapshot_dbg_cli.__version__)
+    self.assertEqual('0.3.4', snapshot_dbg_cli.__version__)


### PR DESCRIPTION
- Removes the use of str.removeprefix, allowing the CLI to run on Python versions prior to 3.9