### PR TITLE
chore: VS Code extension breakpoint syncing tweaks

### DIFF
--- a/snapshot_dbg_extension/package.json
+++ b/snapshot_dbg_extension/package.json
@@ -11,7 +11,7 @@
   "categories": [
     "Debuggers"
   ],
-  "main": "./out/main.js",
+  "main": "./out/extension.js",
   "icon": "media/icon-512.png",
   "activationEvents": [
     "onDebugResolve:snapshotdbg",

--- a/snapshot_dbg_extension/package.json
+++ b/snapshot_dbg_extension/package.json
@@ -11,7 +11,7 @@
   "categories": [
     "Debuggers"
   ],
-  "main": "./out/extension.js",
+  "main": "./out/main.js",
   "icon": "media/icon-512.png",
   "activationEvents": [
     "onDebugResolve:snapshotdbg",

--- a/snapshot_dbg_extension/src/adapter.ts
+++ b/snapshot_dbg_extension/src/adapter.ts
@@ -296,11 +296,13 @@ export class SnapshotDebuggerSession extends DebugSession {
         response.body = response.body || { breakpoints: [] };
         const path = args.source.path!;
         const initialized: boolean = this.initializedPaths.has(path) || this.isDeferredInitializationDone;
-        const sourceBreakpoints = args.breakpoints ?? [];
+        const sourceBreakpoints = [];
         const linesPresent: Set<number> = new Set();
+        let flushServerBreakpointsToIDE: (() => void) | undefined = undefined;
 
         for (const bp of (args.breakpoints ?? [])) {
             linesPresent.add(bp.line);
+            sourceBreakpoints.push({...bp})
         }
 
         for (const bp of sourceBreakpoints) {
@@ -347,17 +349,17 @@ export class SnapshotDebuggerSession extends DebugSession {
             this.ideBreakpoints.applyNewIdeSnapshot(path, sourceBreakpoints);
 
             const localBreakpoints = sourceBreakpoints.map((bp) => CdbgBreakpoint.fromSourceBreakpoint(args.source, bp, this.account));
-            this.breakpointManager!.initializeWithLocalBreakpoints(path, localBreakpoints);
+            flushServerBreakpointsToIDE = this.breakpointManager!.initializeWithLocalBreakpoints(path, localBreakpoints);
 
             this.initializedPaths.add(path);
         }
 
         // The breakpoints in the response must have a 1:1 mapping in the same order as found in the request.
         response.body.breakpoints = [];
-        for (const bp of (args.breakpoints ?? [])) {
+        for (const bp of (sourceBreakpoints)) {
             const cdbg = this.breakpointManager?.getBreakpointBySourceBreakpoint(bp);
             if (cdbg) {
-                response.body.breakpoints.push(cdbg.localBreakpoint);
+                response.body.breakpoints.push({...cdbg.localBreakpoint});
             } else {
                 debugLog("Unexpected breakpoint not found!: "), sourceBreakpointToString(bp);
             }
@@ -366,6 +368,10 @@ export class SnapshotDebuggerSession extends DebugSession {
         debugLog('setBreakpointsResponse:');
         debugLog(response.body);
         this.sendResponse(response);
+
+        if (flushServerBreakpointsToIDE) {
+            flushServerBreakpointsToIDE();
+        }
     }
 
     private runDeferredInitialization(): void {

--- a/snapshot_dbg_extension/src/adapter.ts
+++ b/snapshot_dbg_extension/src/adapter.ts
@@ -342,10 +342,6 @@ export class SnapshotDebuggerSession extends DebugSession {
         } else {
             debugLog('Not initialized for this path yet.  Will attempt to synchronize between IDE and server');
 
-            // Ordering here matters. We need to do the applyNewIdeSnapshot
-            // before the call to initializeWithLocalBreakpoints as that second
-            // call will cause breakpoints to be added to this.ideBreakpoints,
-            // and applyNewIdeSnapshot clobbers all pre-existing data.
             this.ideBreakpoints.applyNewIdeSnapshot(path, sourceBreakpoints);
 
             const localBreakpoints = sourceBreakpoints.map((bp) => CdbgBreakpoint.fromSourceBreakpoint(args.source, bp, this.account));


### PR DESCRIPTION
- Avoid syncing active breakpoints from the backend while the setBreakPointsRequest is active.
- Use a copy of the setBreakPointsRequest input breakpoints and provide copies of the breakpoints in the corresponding response.