### PR TITLE
feat: Add ability to configure connection timeout

### DIFF
--- a/snapshot_dbg_extension/package.json
+++ b/snapshot_dbg_extension/package.json
@@ -84,6 +84,10 @@
               "debugOutput": {
                 "type": "boolean",
                 "description": "If enabled, will output extension debug messages to the console."
+              },
+              "connectionTimeoutMs": {
+                "type": "number",
+                "description": "Timeout for initial firebase database connection, in milliseconds."
               }
             }
           }


### PR DESCRIPTION
The connection timeout is currently hardcoded to 2 seconds.  It is likely that this is not going to work in all situations, so I'm adding a configuration knob to allow the user to set whatever timeout they'd like.

Depending on feedback, the default timeout may be increased as well.  The balance is that if the extension is attempting to discover the database, increases in timeouts will result in slower extension startup.

This PR is related to #135 