### PR TITLE
chore: Update pylintrc to avoid warning

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -424,6 +424,6 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=StandardError,
-                       Exception,
-                       BaseException
+overgeneral-exceptions=builtins.StandardError,
+                       builtins.Exception,
+                       builtins.BaseException

--- a/pylintrc
+++ b/pylintrc
@@ -424,6 +424,6 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=builtins.StandardError,
-                       builtins.Exception,
-                       builtins.BaseException
+overgeneral-exceptions=StandardError,
+                       Exception,
+                       BaseException


### PR DESCRIPTION
Use fully qualified exception names in overgeneral-exceptions option.

This fixes the following warning:

```
pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.BaseException' ?) instead.
```