### PR TITLE
chore: Release CLI 0.3.5

### DIFF
--- a/snapshot_dbg_cli/cli_version.py
+++ b/snapshot_dbg_cli/cli_version.py
@@ -22,7 +22,7 @@ from snapshot_dbg_cli.exceptions import SilentlyExitError
 from snapshot_dbg_cli.http_service import HttpService
 from snapshot_dbg_cli.user_output import UserOutput
 
-VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_3_4'
+VERSION = 'SNAPSHOT_DEBUGGER_CLI_VERSION_0_3_5'
 
 VERSION_PATTERN = 'SNAPSHOT_DEBUGGER_CLI_VERSION_[0-9]+_[0-9]+_[0-9]+'
 

--- a/snapshot_dbg_cli_tests/test_init.py
+++ b/snapshot_dbg_cli_tests/test_init.py
@@ -24,4 +24,4 @@ class CliInitTests(unittest.TestCase):
 
   def test_version_is_expected_value(self):
     # Yes, this will need to be updated for each new version.
-    self.assertEqual('0.3.4', snapshot_dbg_cli.__version__)
+    self.assertEqual('0.3.5', snapshot_dbg_cli.__version__)


### PR DESCRIPTION
The CLI now supports creating the Firebase RTDB in different regions, as listed in
https://firebase.google.com/docs/projects/locations#rtdb-locations. This can be specfied via the `--location` parameter in the `init` command.